### PR TITLE
Fix OS name for Android

### DIFF
--- a/Percy.Tests/metadata/AndroidMetadataTest.cs
+++ b/Percy.Tests/metadata/AndroidMetadataTest.cs
@@ -168,19 +168,7 @@ namespace Percy.Tests
     [Fact]
     public void TestOsName()
     {
-      // Given
-      var _androidPercyAppiumDriver = new Mock<IPercyAppiumDriver>();
-      var capabilities = new Mock<ICapabilities>();
-      capabilities.Setup(x => x.GetCapability("platformName"))
-        .Returns("android");
-      _androidPercyAppiumDriver.Setup(x => x.GetCapabilities())
-        .Returns(capabilities.Object);
-      androidMetadata = new AndroidMetadata(_androidPercyAppiumDriver.Object, "Samsung_gs22u", 0, 0, null, null);
-      var expected = "aNDROID";
-      // When
-      var actual = androidMetadata.OsName();
-      // Then
-      Assert.Equal(actual, expected);
+      Assert.Equal(androidMetadata.OsName(), "Android");
     }
   }
 }

--- a/Percy.Tests/metadata/AndroidMetadataTest.cs
+++ b/Percy.Tests/metadata/AndroidMetadataTest.cs
@@ -9,13 +9,13 @@ namespace Percy.Tests
   public class AndroidMetadataTest
   {
     private AndroidMetadata? androidMetadata;
+    private readonly Mock<IPercyAppiumDriver> _androidPercyAppiumDriver = new Mock<IPercyAppiumDriver>();
 
     [Fact]
     public void TestGetDeviceName_WhenNameIsNotNull()
     {
       // Arrange
       var expected = "Samsung_gs22u";
-      var _androidPercyAppiumDriver = new Mock<IPercyAppiumDriver>();
       androidMetadata = new AndroidMetadata(_androidPercyAppiumDriver.Object, "Samsung_gs22u", 0, 0, null, null);
       // Act
       var actual = androidMetadata.DeviceName();
@@ -32,7 +32,6 @@ namespace Percy.Tests
         {"deviceName", "Samsung_gs22u"}
       };
       var capabilities = new Mock<ICapabilities>();
-      var _androidPercyAppiumDriver = new Mock<IPercyAppiumDriver>();
       capabilities.Setup(x => x.GetCapability("desired"))
         .Returns(deviceDetail);
       _androidPercyAppiumDriver.Setup(x => x.GetCapabilities())
@@ -51,7 +50,6 @@ namespace Percy.Tests
     {
       // Arrange
       var expected = 1420;
-      var _androidPercyAppiumDriver = new Mock<IPercyAppiumDriver>();
       var capabilities = new Mock<ICapabilities>();
       capabilities.Setup(x => x.GetCapability("deviceScreenSize"))
         .Returns("1280x1420");
@@ -70,7 +68,6 @@ namespace Percy.Tests
     {
       // Arrange
       var expected = 1280;
-      var _androidPercyAppiumDriver = new Mock<IPercyAppiumDriver>();
       var capabilities = new Mock<ICapabilities>();
       capabilities.Setup(x => x.GetCapability("deviceScreenSize"))
         .Returns("1280x1420");
@@ -90,7 +87,6 @@ namespace Percy.Tests
       // Arrange
       AppPercy.cache.Clear();
       var expected = 320;
-      var _androidPercyAppiumDriver = new Mock<IPercyAppiumDriver>();
       var capabilities = new Mock<ICapabilities>();
       var viewport = new Dictionary<string, object>(){
         {"top", 100L},
@@ -115,7 +111,6 @@ namespace Percy.Tests
     {
       // Arrange
       var expected = 100;
-      var _androidPercyAppiumDriver = new Mock<IPercyAppiumDriver>();
       var capabilities = new Mock<ICapabilities>();
       androidMetadata = new AndroidMetadata(_androidPercyAppiumDriver.Object, "Samsung_gs22u", 0, 100, null, null);
       // Act
@@ -131,7 +126,6 @@ namespace Percy.Tests
       // Arrange
       AppPercy.cache.Clear();
       var expected = 100;
-      var _androidPercyAppiumDriver = new Mock<IPercyAppiumDriver>();
       var capabilities = new Mock<ICapabilities>();
       var viewportRect = new Dictionary<string, object>(){
         {"top", 100L}
@@ -155,7 +149,6 @@ namespace Percy.Tests
     {
       // Arrange
       var expected = 100;
-      var _androidPercyAppiumDriver = new Mock<IPercyAppiumDriver>();
       var capabilities = new Mock<ICapabilities>();
       androidMetadata = new AndroidMetadata(_androidPercyAppiumDriver.Object, "Samsung_gs22u", 100, -1, null, null);
       // Act

--- a/Percy.Tests/metadata/AndroidMetadataTest.cs
+++ b/Percy.Tests/metadata/AndroidMetadataTest.cs
@@ -168,6 +168,7 @@ namespace Percy.Tests
     [Fact]
     public void TestOsName()
     {
+      androidMetadata = new AndroidMetadata(_androidPercyAppiumDriver.Object, "Samsung_gs22u", 0, 100, null, null);
       Assert.Equal(androidMetadata.OsName(), "Android");
     }
   }

--- a/Percy.Tests/metadata/IosMetadataTest.cs
+++ b/Percy.Tests/metadata/IosMetadataTest.cs
@@ -87,17 +87,7 @@ namespace Percy.Tests
     [Fact]
     public void TestOsName()
     {
-      // Given
-      capabilities.Setup(x => x.GetCapability("platformName"))
-         .Returns("ios");
-      _iPhonePercyAppiumDriver.Setup(x => x.GetCapabilities())
-        .Returns(capabilities.Object);
-      iosMetadata = new IosMetadata(_iPhonePercyAppiumDriver.Object, "Samsung_gs22u", 0, 0, null, null);
-      var expected = "iOS";
-      // When
-      var actual = iosMetadata.OsName();
-      // Then
-      Assert.Equal(actual, expected);
+      Assert.Equal(iosMetadata.OsName(), "iOS");
     }
 
     [Fact]

--- a/Percy.Tests/metadata/IosMetadataTest.cs
+++ b/Percy.Tests/metadata/IosMetadataTest.cs
@@ -87,6 +87,7 @@ namespace Percy.Tests
     [Fact]
     public void TestOsName()
     {
+      iosMetadata = new IosMetadata(_iPhonePercyAppiumDriver.Object, "iPhone_11", 100, -1, null, null);
       Assert.Equal(iosMetadata.OsName(), "iOS");
     }
 

--- a/Percy.Tests/providers/GenericProviderTest.cs
+++ b/Percy.Tests/providers/GenericProviderTest.cs
@@ -56,7 +56,7 @@ namespace Percy.Tests
       // Then
       var tile = genericProvider.GetTag();
       Assert.Equal(tile.GetValue("name").ToString(), "Samsung Galaxy s22");
-      Assert.Equal(tile.GetValue("osName").ToString(), "aNDROID");
+      Assert.Equal(tile.GetValue("osName").ToString(), "Android");
       Assert.Equal(tile.GetValue("osVersion").ToString(), "9");
       Assert.Equal(Convert.ToInt32(tile.GetValue("width")), 1280);
       Assert.Equal(Convert.ToInt32(tile.GetValue("height")), 1420);
@@ -140,7 +140,7 @@ namespace Percy.Tests
     public void TestScreenshot()
     {
       // Given
-      string expected = "https://percy.io/api/v1/comparisons/redirect?snapshot[name]=test%20screenshot&tag[name]=Samsung&tag[os_name]=aNDROID&tag[os_version]=9&tag[width]=1280&tag[height]=1420&tag[orientation]=landscape";
+      string expected = "https://percy.io/api/v1/comparisons/redirect?snapshot[name]=test%20screenshot&tag[name]=Samsung&tag[os_name]=Android&tag[os_version]=9&tag[width]=1280&tag[height]=1420&tag[orientation]=landscape";
       string url = "http://hub-cloud.browserstack.com/wd/hub";
       AppPercy.cache.Clear();
       capabilities.Setup(x => x.GetCapability("platformName"))

--- a/Percy/Percy.csproj
+++ b/Percy/Percy.csproj
@@ -9,7 +9,7 @@
     <PackageId>PercyIO.Appium</PackageId>
     <Description>An App Percy SDK for Appium WebDriver API .NET Bindings</Description>
     <PackageTags>appium;percy;visual;testing</PackageTags>
-    <Version>1.2.3</Version>
+    <Version>1.2.4</Version>
     <Company>Perceptual Inc</Company>
     <Copyright>Copyright Perceptual Inc</Copyright>
     <Authors>percy-admin</Authors>

--- a/Percy/lib/CliWrapper.cs
+++ b/Percy/lib/CliWrapper.cs
@@ -18,7 +18,7 @@ namespace PercyIO.Appium
   {
     public static readonly string CLI_API =
     Environment.GetEnvironmentVariable("PERCY_CLI_API") ?? "http://localhost:5338";
-    public static readonly string CLIENT_INFO = "percy-appium-dotnet/" + Assembly.GetEntryAssembly().GetCustomAttribute<AssemblyInformationalVersionAttribute>().InformationalVersion;
+    public static readonly string CLIENT_INFO = "percy-appium-dotnet/1.2.4";
     public static readonly string ENVIRONMENT_INFO = Regex.Replace(
         Regex.Replace(RuntimeInformation.FrameworkDescription, @"\s+", "-"),
         @"-([\d\.]+).*$", "/$1").Trim().ToLower();

--- a/Percy/metadata/AndroidMetadata.cs
+++ b/Percy/metadata/AndroidMetadata.cs
@@ -38,8 +38,7 @@ namespace PercyIO.Appium
 
     internal override string OsName()
     {
-      var osName = driver.GetCapabilities().GetCapability("platformName").ToString();
-      return osName.Substring(0, 1).ToLower() + osName.Substring(1).ToUpper();
+      return "Android";
     }
     internal override int DeviceScreenWidth()
     {

--- a/Percy/metadata/IosMetadata.cs
+++ b/Percy/metadata/IosMetadata.cs
@@ -26,8 +26,7 @@ namespace PercyIO.Appium
 
     internal override string OsName()
     {
-      var osName = driver.GetCapabilities().GetCapability("platformName").ToString();
-      return osName.Substring(0, 1).ToLower() + osName.Substring(1).ToUpper();
+      return "iOS";
     }
 
     internal override int DeviceScreenHeight()


### PR DESCRIPTION
- Don't fetch OSname from caps, we can use hardcoded values here.
- Jira: https://browserstack.atlassian.net/browse/PAPP-267
- Version bump
- We need to hardcode package version, since Assembly returns the information version of main app.