### PR TITLE
fix: add appium: prefix fallback and null safety for capability access

### DIFF
--- a/Percy/lib/PercyAppiumCapabilities.cs
+++ b/Percy/lib/PercyAppiumCapabilities.cs
@@ -7,6 +7,15 @@ namespace PercyIO.Appium
   internal class PercyAppiumCapabilities : IPercyAppiumCapabilities
   {
     private Dictionary<string, object> capabilites;
+
+    // W3C WebDriver standard capabilities that never need vendor prefix
+    private static readonly HashSet<string> W3CStandardCaps = new HashSet<string>
+    {
+      "browserName", "browserVersion", "platformName",
+      "acceptInsecureCerts", "pageLoadStrategy", "proxy",
+      "timeouts", "unhandledPromptBehavior"
+    };
+
     internal PercyAppiumCapabilities()
     {
 
@@ -18,10 +27,25 @@ namespace PercyIO.Appium
 
     public T getValue<T>(String key)
     {
-      if(capabilites.ContainsKey(key) && capabilites[key] is T result)
+      if (capabilites == null) return default(T);
+
+      // W3C standard caps only use bare key
+      if (W3CStandardCaps.Contains(key))
       {
-        return result;
+        if (capabilites.ContainsKey(key) && capabilites[key] is T result)
+          return result;
+        return default(T);
       }
+
+      // Try bare key first (Appium 1.x or already-resolved)
+      if (capabilites.ContainsKey(key) && capabilites[key] is T bareResult)
+        return bareResult;
+
+      // Then try appium: prefixed key (Appium 2.x W3C protocol)
+      string prefixedKey = "appium:" + key;
+      if (capabilites.ContainsKey(prefixedKey) && capabilites[prefixedKey] is T prefixedResult)
+        return prefixedResult;
+
       return default(T);
     }
 

--- a/Percy/lib/PercyOptions.cs
+++ b/Percy/lib/PercyOptions.cs
@@ -23,7 +23,8 @@ namespace PercyIO.Appium
         Utils.Log("Percy options not provided in capabilitiies, considering enabled", "debug");
         return true;
       }
-      else if (percyEnabledJsonProtocol.IsFalse() || (percyOptionsW3CProtocol?["enabled"].IsFalse() ?? false))
+      else if ((percyEnabledJsonProtocol != null && percyEnabledJsonProtocol.IsFalse())
+        || (percyOptionsW3CProtocol != null && percyOptionsW3CProtocol.TryGetValue("enabled", out var enabledVal) && enabledVal.IsFalse()))
       {
         Utils.Log("App Percy is disabled in capabilities");
         return false;
@@ -40,7 +41,8 @@ namespace PercyIO.Appium
         Utils.Log("Percy options not provided in capabilitiies, ignoring errors by default", "debug");
         return;
       }
-      else if (percyIgnoreErrorsJsonProtocol.IsFalse() || percyOptionsW3CProtocol["ignoreErrors"].IsFalse())
+      else if ((percyIgnoreErrorsJsonProtocol != null && percyIgnoreErrorsJsonProtocol.IsFalse())
+        || (percyOptionsW3CProtocol != null && percyOptionsW3CProtocol.TryGetValue("ignoreErrors", out var ignoreVal) && ignoreVal.IsFalse()))
       {
         AppPercy.ignoreErrors = false;
       }

--- a/Percy/metadata/AndroidMetadata.cs
+++ b/Percy/metadata/AndroidMetadata.cs
@@ -25,8 +25,14 @@ namespace PercyIO.Appium
       var device = driver.GetCapabilities().getValue<String>("device");
       if (device == null)
       {
-        Dictionary<string, object> desiredCaps = driver.GetCapabilities().getValue<Dictionary<string, object>>("desired")!;
-        return desiredCaps.TryGetValue("deviceName", out var value) ? value.ToString() : "";
+        // Try "desired" caps (Appium 1.x JSONWP protocol); may be null in Appium 2.x W3C protocol
+        Dictionary<string, object> desiredCaps = driver.GetCapabilities().getValue<Dictionary<string, object>>("desired");
+        if (desiredCaps != null && desiredCaps.TryGetValue("deviceName", out var value))
+          return value.ToString();
+
+        // Fallback: try deviceName directly from capabilities (Appium 2.x)
+        var capsDeviceName = driver.GetCapabilities().getValue<String>("deviceName");
+        return capsDeviceName ?? "";
       }
       return device;
     }
@@ -34,7 +40,10 @@ namespace PercyIO.Appium
     internal override int DeviceScreenHeight()
     {
       var deviceScreenSize = driver.GetCapabilities().getValue<String>("deviceScreenSize");
-      return Int16.Parse(deviceScreenSize.Split('x')[1]);
+      if (deviceScreenSize != null)
+        return Int16.Parse(deviceScreenSize.Split('x')[1]);
+      var viewportRect = GetViewportRect();
+      return viewportRect != null && viewportRect.TryGetValue("height", out var value) ? (int)(long)value : 0;
     }
 
     internal override string OsName()
@@ -44,7 +53,10 @@ namespace PercyIO.Appium
     internal override int DeviceScreenWidth()
     {
       var deviceScreenSize = driver.GetCapabilities().getValue<String>("deviceScreenSize");
-      return Int16.Parse(deviceScreenSize.Split('x')[0]);
+      if (deviceScreenSize != null)
+        return Int16.Parse(deviceScreenSize.Split('x')[0]);
+      var viewportRect = GetViewportRect();
+      return viewportRect != null && viewportRect.TryGetValue("width", out var value) ? (int)(long)value : 0;
     }
 
     internal override int NavBarHeight()
@@ -73,7 +85,7 @@ namespace PercyIO.Appium
     {
       if (AppPercy.cache.Get("viewportRect_" + sessionId) == null)
       {
-        var viewportRect = driver.GetCapabilities().getValue<Dictionary<string, object>>("viewportRect")!;
+        var viewportRect = driver.GetCapabilities().getValue<Dictionary<string, object>>("viewportRect");
         AppPercy.cache.Store("viewportRect_" + sessionId, viewportRect);
       }
       return (Dictionary<string, object>)AppPercy.cache.Get("viewportRect_" + sessionId);

--- a/Percy/metadata/IosMetadata.cs
+++ b/Percy/metadata/IosMetadata.cs
@@ -21,7 +21,9 @@ namespace PercyIO.Appium
       {
         return deviceName;
       }
-      return driver.GetCapabilities().getValue<String>("deviceName")!;
+      return driver.GetCapabilities().getValue<String>("deviceName")
+        ?? driver.GetCapabilities().getValue<String>("device")
+        ?? "";
     }
 
     internal override string OsName()

--- a/Percy/providers/AppAutomate.cs
+++ b/Percy/providers/AppAutomate.cs
@@ -232,7 +232,7 @@ namespace PercyIO.Appium
       {
         Utils.Log("Unable to fetch Appium version, Appium version should be >= 1.19 for Fullpage Screenshot", "warn");
       }
-      else if ((appiumVersionJsonProtocol != null && !AppiumVersionCheck(appiumVersionJsonProtocol)) || (bstackOptions != null && !AppiumVersionCheck(bstackOptions["appiumVersion"].ToString())))
+      else if ((appiumVersionJsonProtocol != null && !AppiumVersionCheck(appiumVersionJsonProtocol)) || (bstackOptions != null && bstackOptions.TryGetValue("appiumVersion", out var appiumVer) && appiumVer != null && !AppiumVersionCheck(appiumVer.ToString())))
       {
         Utils.Log("Appium version should be >= 1.19 for Fullpage Screenshot, Falling back to single page screenshot.", "warn");
         return false;


### PR DESCRIPTION
## Summary
- Add W3C standard caps awareness and `appium:` prefix fallback to `getValue<T>()` for Appium 2.x W3C protocol compatibility
- Fix `NullReferenceException` risks across multiple files when capabilities are null (e.g. iOS BrowserStack sessions)
- Safe dictionary access patterns replacing forced non-null operators and direct key indexing

## What was broken
On iOS BrowserStack real device sessions:
- `desired` capability is undefined → `getValue<Dictionary>("desired")!` throws NRE
- `deviceScreenSize` is missing → `.Split('x')` on null string throws NRE
- `deviceName` may not resolve → forced `!` throws NRE

On Appium 2.x W3C protocol:
- Non-standard capabilities require `appium:` prefix which wasn't tried as fallback

In PercyOptions:
- When only one protocol format (JSONWP or W3C) was present, the other null reference was dereferenced on the `else if` branch

## Changes
| File | Change |
|------|--------|
| `PercyAppiumCapabilities.cs` | W3C standard caps set, bare→appium: prefix fallback, null-safe when capabilities is null |
| `AndroidMetadata.cs` | Safe `desired` access with `deviceName` fallback, null-safe `deviceScreenSize` with `viewportRect` fallback, remove forced `!` on `viewportRect` |
| `IosMetadata.cs` | Null-safe `deviceName` with `device` fallback chain |
| `PercyOptions.cs` | Fix NRE in `PercyEnabled()` and `SetPercyIgnoreErrors()` using explicit null checks and `TryGetValue` |
| `AppAutomate.cs` | Safe `TryGetValue` for `appiumVersion` in `bstackOptions` dictionary |

## Test plan
- [ ] Run existing test suite to verify no regressions
- [ ] Test with Appium 1.x session (JSONWP protocol) — verify bare keys still work
- [ ] Test with Appium 2.x session (W3C protocol) — verify `appium:` prefix fallback works
- [ ] Test with iOS BrowserStack session — verify no NRE when `desired`/`deviceScreenSize` are missing
- [ ] Test Percy options parsing when only one protocol format is present

🤖 Generated with [Claude Code](https://claude.ai/code)