### PR TITLE
test: coverlet coverage gate + raise coverage 82% → 99.4%

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,8 @@ obj
 .DS_Store?
 coveragereport
 TestResults
+
+# coverlet msbuild output
+coverage.cobertura.xml
+coverage.json
+coverage.*.json

--- a/Percy.Tests/AppPercyTest.cs
+++ b/Percy.Tests/AppPercyTest.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Dynamic;
 using Xunit;
 using PercyIO.Appium;
 using RichardSzalay.MockHttp;
@@ -129,7 +130,7 @@ namespace Percy.Tests
       mockDriver.setIsV5(true);
       mockDriver.SetCapability(MetadataBuilder.CapabilityBuilder("iOS"));
       mockDriver.setCommandExecutor("https://browserstack.com/wd/hub");
-      
+
       // Act
       AppPercy appPercy = new AppPercy(mockDriver);
       var name = "dummyName";
@@ -140,6 +141,150 @@ namespace Percy.Tests
       } catch (Exception) {
 
       }
+    }
+
+    [Fact]
+    public void Screenshot_ReturnsNull_WhenPercyDisabledInCapabilities()
+    {
+      // Arrange — percyOptions.enabled = false in capabilities so PercyEnabled() is false.
+      dynamic percyOption = new ExpandoObject();
+      percyOption.jwp = false;
+      percyOption.percyEnabled = "False";
+      percyOption.ignoreError = "False";
+      mockDriver.SetCapability(MetadataBuilder.CapabilityBuilder("Android", percyOption));
+      mockDriver.setCommandExecutor("https://browserstack.com/wd/hub");
+
+      // Act
+      AppPercy appPercy = new AppPercy(mockDriver);
+      var result = appPercy.Screenshot("disabled", null);
+
+      // Assert — early return, no screenshot taken.
+      Assert.Null(result);
+    }
+
+    [Fact]
+    public void Screenshot_ReturnsData_WhenResponseContainsDataKey()
+    {
+      // Arrange — respond with a payload that carries a "data" object so the
+      // data extraction branch returns it.
+      mockDriver.SetCapability(MetadataBuilder.CapabilityBuilder("Android"));
+      mockDriver.setCommandExecutor("https://browserstack.com/wd/hub");
+
+      var mockHttp = new MockHttpMessageHandler();
+      var obj = new
+      {
+        success = true,
+        data = new { snapshot = "snapshot-name" }
+      };
+      mockHttp.When("http://localhost:5338/percy/comparison")
+        .Respond("application/json", JsonConvert.SerializeObject(obj));
+      CliWrapper.setHttpClient(new HttpClient(mockHttp));
+
+      // Act
+      AppPercy appPercy = new AppPercy(mockDriver);
+      var result = appPercy.Screenshot("with-data", null);
+
+      // Assert
+      Assert.NotNull(result);
+      Assert.Equal("snapshot-name", result.GetValue("snapshot").ToString());
+      CliWrapper.resetHttpClient();
+    }
+
+    [Fact]
+    public void Screenshot_SwallowsPercyException_WhenIgnoreErrorsTrue()
+    {
+      // Arrange — driver whose screenshot capture raises a PercyException; default
+      // ignoreErrors swallows it, posts a failed event and returns null.
+      AppPercy.ignoreErrors = true;
+      var throwingDriver = new ThrowingDriverObject();
+      throwingDriver.SessionId = "session-throw";
+      throwingDriver.SetCapability(MetadataBuilder.CapabilityBuilder("Android"));
+      throwingDriver.setCommandExecutor("https://browserstack.com/wd/hub");
+
+      var mockHttp = new MockHttpMessageHandler();
+      mockHttp.Fallback.Respond("application/json", JsonConvert.SerializeObject(new { success = true }));
+      CliWrapper.setHttpClient(new HttpClient(mockHttp));
+
+      // Act
+      AppPercy appPercy = new AppPercy(throwingDriver);
+      var result = appPercy.Screenshot("boom", null);
+
+      // Assert
+      Assert.Null(result);
+      Assert.Contains(LogMessage("percy:dotnet", "The method is not valid for current driver. Please contact us.", "93m"), stringWriter.ToString());
+      Assert.Contains(LogMessage("percy", "Error taking screenshot boom"), stringWriter.ToString());
+      CliWrapper.resetHttpClient();
+    }
+
+    [Fact]
+    public void Screenshot_Rethrows_WhenIgnoreErrorsFalse()
+    {
+      // Arrange — same throwing driver but ignoreErrors disabled, so it rethrows.
+      AppPercy.ignoreErrors = false;
+      var throwingDriver = new ThrowingDriverObject();
+      throwingDriver.SessionId = "session-throw";
+      throwingDriver.SetCapability(MetadataBuilder.CapabilityBuilder("Android"));
+      throwingDriver.setCommandExecutor("https://browserstack.com/wd/hub");
+
+      var mockHttp = new MockHttpMessageHandler();
+      mockHttp.Fallback.Respond("application/json", JsonConvert.SerializeObject(new { success = true }));
+      CliWrapper.setHttpClient(new HttpClient(mockHttp));
+
+      // Act + Assert
+      AppPercy appPercy = new AppPercy(throwingDriver);
+      var ex = Assert.Throws<Exception>(() => appPercy.Screenshot("boom", null));
+      Assert.Equal("Error taking screenshot boom", ex.Message);
+
+      // Reset shared static so later tests keep default behaviour.
+      AppPercy.ignoreErrors = true;
+      CliWrapper.resetHttpClient();
+    }
+  }
+
+  // Mirrors MockDriverObject but raises a PercyException during screenshot capture,
+  // driving AppPercy.Screenshot's catch block (failed-event post + PercyException warn).
+  internal class ThrowingDriverObject
+  {
+    private MockCapabilities mockCapabilities;
+    public String SessionId { get; set; }
+    public MockCapabilities Capabilities
+    {
+      get
+      {
+        return mockCapabilities;
+      }
+    }
+
+    public void SetCapability(Dictionary<string, object> caps)
+    {
+      mockCapabilities = new MockCapabilities();
+      mockCapabilities.Capabilities = caps;
+    }
+
+    private CommandExecutor commandExecutor;
+
+    CommandExecutor CommandExecutor
+    {
+      get
+      {
+        return commandExecutor;
+      }
+    }
+
+    public void setCommandExecutor(String url)
+    {
+      commandExecutor = new CommandExecutor();
+      commandExecutor.SetUrl(url);
+    }
+
+    public Object ExecuteScript(String script)
+    {
+      return @"{success:'true', osVersion:'11.2', buildHash:'abc', sessionHash:'def'}";
+    }
+
+    public Object GetScreenshot()
+    {
+      throw new PercyException("Screenshot not available on this driver");
     }
   }
 }

--- a/Percy.Tests/EnvTest.cs
+++ b/Percy.Tests/EnvTest.cs
@@ -1,0 +1,29 @@
+using System;
+using Xunit;
+using PercyIO.Appium;
+
+namespace Percy.Tests
+{
+  public class EnvTest
+  {
+    [Fact]
+    public void SetAndGetPercyBuildID()
+    {
+      // Act
+      Env.SetPercyBuildID("build-123");
+
+      // Assert
+      Assert.Equal("build-123", Env.GetPercyBuildID());
+    }
+
+    [Fact]
+    public void SetAndGetPercyBuildUrl()
+    {
+      // Act
+      Env.SetPercyBuildUrl("https://percy.io/builds/123");
+
+      // Assert
+      Assert.Equal("https://percy.io/builds/123", Env.GetPercyBuildUrl());
+    }
+  }
+}

--- a/Percy.Tests/Percy.Tests.csproj
+++ b/Percy.Tests/Percy.Tests.csproj
@@ -22,6 +22,10 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
+    <PackageReference Include="coverlet.msbuild" Version="3.2.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
     <PackageReference Include="Moq" Version="4.18.4" />
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />

--- a/Percy.Tests/PercyOnAutomateTest.cs
+++ b/Percy.Tests/PercyOnAutomateTest.cs
@@ -149,5 +149,109 @@ namespace Percy.Tests
       Assert.Contains(LogMessage("percy", $"Could not take screenshot \"Screenshot 1\"\n"), stringWriter.ToString());
       mockHttp.VerifyNoOutstandingExpectation();
     }
+
+    [Fact]
+    public void postScreenshotWithConsiderRegionElements()
+    {
+      // Covers the consider_region_appium_elements branch (lines 44-52)
+      TestHelper.UnsetEnvVariables();
+      mockDriver.SetCapability(MetadataBuilder.CapabilityBuilder("Android"));
+      mockDriver.setCommandExecutor("https://browserstack.com/wd/hub");
+      PercyOnAutomate percy = new PercyOnAutomate(mockDriver);
+
+      var mockHttp = new MockHttpMessageHandler();
+      var obj = new
+      {
+        success = true,
+        version = "1.0",
+      };
+      mockHttp.Fallback.Respond(new HttpClient());
+
+      var element = new MockAppiumElement();
+      var elementList = new List<object> { element };
+      Dictionary<string, object> options = new Dictionary<string, object>();
+      options["consider_region_appium_elements"] = elementList;
+
+      mockHttp.Expect(HttpMethod.Post, "http://localhost:5338/percy/automateScreenshot")
+        .WithPartialContent("Screenshot 1")
+        .WithPartialContent("https://browserstack.com/wd/hub")
+        .WithPartialContent("session-1")
+        .WithPartialContent(" \"platformName\": \"Android\"")
+        .WithPartialContent("consider_region_elements")
+        .WithPartialContent("element_id")
+        .Respond("application/json", JsonConvert.SerializeObject(obj));
+      CliWrapper.setHttpClient(new HttpClient(mockHttp));
+      percy.Screenshot("Screenshot 1", options);
+
+      mockHttp.VerifyNoOutstandingExpectation();
+    }
+
+    [Fact]
+    public void postScreenshotWithIgnoreAndConsiderRegionElements()
+    {
+      // Covers both ignore (34-42) and consider (44-52) branches together
+      TestHelper.UnsetEnvVariables();
+      mockDriver.SetCapability(MetadataBuilder.CapabilityBuilder("Android"));
+      mockDriver.setCommandExecutor("https://browserstack.com/wd/hub");
+      PercyOnAutomate percy = new PercyOnAutomate(mockDriver);
+
+      var mockHttp = new MockHttpMessageHandler();
+      var obj = new
+      {
+        success = true,
+        version = "1.0",
+      };
+      mockHttp.Fallback.Respond(new HttpClient());
+
+      var elementList = new List<object> { new MockAppiumElement() };
+      Dictionary<string, object> options = new Dictionary<string, object>();
+      options["ignore_region_appium_elements"] = elementList;
+      options["consider_region_appium_elements"] = elementList;
+
+      mockHttp.Expect(HttpMethod.Post, "http://localhost:5338/percy/automateScreenshot")
+        .WithPartialContent("ignore_region_elements")
+        .WithPartialContent("consider_region_elements")
+        .WithPartialContent("element_id")
+        .Respond("application/json", JsonConvert.SerializeObject(obj));
+      CliWrapper.setHttpClient(new HttpClient(mockHttp));
+      percy.Screenshot("Screenshot 1", options);
+
+      mockHttp.VerifyNoOutstandingExpectation();
+    }
+
+    [Fact]
+    public void postScreenshotCatchesException()
+    {
+      // Covers the catch block (lines 58-62): a non-element object in the ignore list
+      // makes GetElementIds -> PercyAppiumElement reflection throw, which the Screenshot
+      // try/catch swallows and returns null.
+      TestHelper.UnsetEnvVariables();
+      mockDriver.SetCapability(MetadataBuilder.CapabilityBuilder("Android"));
+      mockDriver.setCommandExecutor("https://browserstack.com/wd/hub");
+      PercyOnAutomate percy = new PercyOnAutomate(mockDriver);
+
+      // A non-element object causes GetElementIds -> PercyAppiumElement reflection to throw,
+      // which is caught by the Screenshot catch block.
+      Dictionary<string, object> options = new Dictionary<string, object>();
+      options["ignore_region_appium_elements"] = new List<object> { new object() };
+
+      var result = percy.Screenshot("Screenshot 1", options);
+
+      Assert.Null(result);
+      Assert.Contains(LogMessage("percy", $"Could not take Percy Screenshot \"Screenshot 1\"\n"), stringWriter.ToString());
+    }
+
+    [Fact]
+    public void screenshotWithScreenshotOptionsThrows()
+    {
+      // Covers the second Screenshot overload (lines 65-66)
+      TestHelper.UnsetEnvVariables();
+      mockDriver.SetCapability(MetadataBuilder.CapabilityBuilder("Android"));
+      mockDriver.setCommandExecutor("https://browserstack.com/wd/hub");
+      PercyOnAutomate percy = new PercyOnAutomate(mockDriver);
+
+      var ex = Assert.Throws<Exception>(() => percy.Screenshot("Screenshot 1", new ScreenshotOptions(), false));
+      Assert.Equal("Options need to be passed using Dictionary for: Screenshot 1", ex.Message);
+    }
   }
 }

--- a/Percy.Tests/PercyTest.cs
+++ b/Percy.Tests/PercyTest.cs
@@ -77,10 +77,34 @@ namespace Percy.Tests
       mockHttp.Expect("http://localhost:5338/percy/comparison")
               .Respond("application/json", JsonConvert.SerializeObject(obj));
       CliWrapper.setHttpClient(new HttpClient(mockHttp));
-      
+
       percy.Screenshot("Screenshot 4");
       mockHttp.VerifyNoOutstandingExpectation();
       Environment.SetEnvironmentVariable("PERCY_DISABLE_REMOTE_UPLOADS", "false");
+    }
+
+    [Fact]
+    public void shouldSkipWhenPercyNotEnabled()
+    {
+      // Arrange — healthcheck disabled means the factory returns early without
+      // resolving a percy class, and Screenshot is a no-op.
+      TestHelper.UnsetEnvVariables();
+      CliWrapper.Healthcheck = () =>
+      {
+        return false;
+      };
+      mockDriver.SetCapability(MetadataBuilder.CapabilityBuilder("Android"));
+      mockDriver.setCommandExecutor("https://browserstack.com/wd/hub");
+
+      var mockHttp = new MockHttpMessageHandler();
+      CliWrapper.setHttpClient(new HttpClient(mockHttp));
+
+      // Act — constructor returns at the disabled guard, Screenshot returns at its guard.
+      var percy = new PercyIO.Appium.Percy(mockDriver);
+      percy.Screenshot("Screenshot 4");
+
+      // Assert — no screenshot request was ever made.
+      mockHttp.VerifyNoOutstandingExpectation();
     }
   }
 }

--- a/Percy.Tests/lib/IgnoreRegionTest.cs
+++ b/Percy.Tests/lib/IgnoreRegionTest.cs
@@ -91,5 +91,35 @@ namespace Percy.Tests
       // Assert
       Assert.False(isValid);
     }
+
+    [Fact]
+    public void IsValid_ReturnsFalse_WhenTopIsNotLessThanBottom()
+    {
+      // Arrange — top >= bottom, so the region is inverted/degenerate.
+      IgnoreRegion region = new IgnoreRegion(20, 10, 5, 50);
+      var width = 1080;
+      var height = 2500;
+
+      // Act
+      bool isValid = region.IsValid(height, width);
+
+      // Assert
+      Assert.False(isValid);
+    }
+
+    [Fact]
+    public void IsValid_ReturnsFalse_WhenLeftIsNotLessThanRight()
+    {
+      // Arrange — left >= right, so the region is inverted/degenerate.
+      IgnoreRegion region = new IgnoreRegion(10, 20, 60, 40);
+      var width = 1080;
+      var height = 2500;
+
+      // Act
+      bool isValid = region.IsValid(height, width);
+
+      // Assert
+      Assert.False(isValid);
+    }
   }
 }

--- a/Percy.Tests/lib/PercyAppiumDriverTest.cs
+++ b/Percy.Tests/lib/PercyAppiumDriverTest.cs
@@ -1,0 +1,278 @@
+using System;
+using System.Collections.Generic;
+using PercyIO.Appium;
+using Xunit;
+
+namespace Percy.Tests
+{
+  public class PercyAppiumDriverTest
+  {
+    public PercyAppiumDriverTest()
+    {
+      AppPercy.cache.Clear();
+      TestHelper.UnsetEnvVariables();
+    }
+
+    // ---- Test doubles -------------------------------------------------------
+    // These plain objects are passed (as System.Object) to the PercyAppiumDriver
+    // constructor. PercyAppiumDriver reflects over them via ReflectionUtils, so the
+    // member shapes below mirror what the real Appium driver exposes.
+
+    private class WindowSize
+    {
+      public int Width { get; set; } = 360;
+      public int Height { get; set; } = 640;
+    }
+
+    private class Window
+    {
+      public WindowSize Size { get; } = new WindowSize();
+    }
+
+    private class Manager
+    {
+      public Window Window { get; } = new Window();
+    }
+
+    // ToString() returns null on purpose so PercyAppiumDriver.sessionId() yields
+    // null and getSessionId() falls into the dynamic-driver fallback branch.
+    private class NullStringSessionId
+    {
+      public override string ToString() => null!;
+    }
+
+    // Full-featured fake driver covering the happy-path reflective members.
+    private class FakeDriver
+    {
+      public List<object> ExecuteScriptArgs = new List<object>();
+      public string? OrientationValue;
+      public object SessionIdValue = "session-123";
+      public string ScriptReturn = "script-result";
+
+      public string? Orientation => OrientationValue;
+      public object SessionId => SessionIdValue;
+
+      public Manager Manage() => new Manager();
+
+      public object ExecuteScript(string script, object[] args)
+      {
+        ExecuteScriptArgs.Add(script);
+        ExecuteScriptArgs.Add(args);
+        return ScriptReturn;
+      }
+
+      public object FindElement(string by, string value)
+      {
+        return new MockAppiumElement();
+      }
+    }
+
+    // Driver whose FindElement(string,string) returns null -> wrapper returns null.
+    private class NullElementDriver
+    {
+      public object FindElement(string by, string value) => null!;
+    }
+
+    // Driver that has no FindElement(string,string) overload at all
+    // (only a different signature), exercising the method == null branch.
+    private class NoFindElementDriver
+    {
+      public object FindElement(string only) => null!;
+    }
+
+    // Driver whose FindElement(string,string) throws, exercising the catch branch.
+    private class ThrowingFindElementDriver
+    {
+      public object FindElement(string by, string value)
+      {
+        throw new InvalidOperationException("boom");
+      }
+    }
+
+    // Driver without an ExecuteScript(string, object[]) overload -> private
+    // ExecuteScript returns null.
+    private class NoExecuteScriptDriver
+    {
+    }
+
+    // ---- CommandExecutor shapes for GetHost ---------------------------------
+
+    private class InternalExecutorHolder
+    {
+      private object remoteServerUri;
+      public void SetUrl(string url) => remoteServerUri = new Uri(url);
+    }
+
+    // V5-style executor that exposes `internalExecutor` (and no RealExecutor),
+    // forcing GetHostV5 down the internalExecutor branch.
+    private class InternalExecutorCommandExecutor
+    {
+      private object internalExecutor;
+      public InternalExecutorCommandExecutor(string url)
+      {
+        var holder = new InternalExecutorHolder();
+        holder.SetUrl(url);
+        internalExecutor = holder;
+      }
+    }
+
+    private class InternalExecutorDriver
+    {
+      private object commandExecutor;
+      public InternalExecutorDriver(string url)
+      {
+        commandExecutor = new InternalExecutorCommandExecutor(url);
+      }
+      public object CommandExecutor => commandExecutor;
+    }
+
+    // ---- Tests --------------------------------------------------------------
+
+    // Lines 22-25
+    [Fact]
+    public void Orientation_ReturnsDriverOrientation()
+    {
+      var raw = new FakeDriver { OrientationValue = "LANDSCAPE" };
+      var driver = new PercyAppiumDriver(raw);
+
+      Assert.Equal("LANDSCAPE", driver.Orientation());
+    }
+
+    // Lines 59-65
+    [Fact]
+    public void DownscaledWidth_ReturnsWindowSizeWidth()
+    {
+      var raw = new FakeDriver();
+      var driver = new PercyAppiumDriver(raw);
+
+      Assert.Equal(360, driver.DownscaledWidth());
+    }
+
+    // Lines 67-70 (public) + 197-203 (private ExecuteScript happy path)
+    [Fact]
+    public void ExecuteDriverScript_DelegatesToReflectedExecuteScript()
+    {
+      var raw = new FakeDriver { ScriptReturn = "driver-script-out" };
+      var driver = new PercyAppiumDriver(raw);
+
+      var result = driver.ExecuteDriverScript("myScript");
+
+      Assert.Equal("driver-script-out", result);
+      Assert.Equal("myScript", raw.ExecuteScriptArgs[0]);
+    }
+
+    // Lines 53-57 (public ExecuteScript) + 202-203
+    [Fact]
+    public void ExecuteScript_ReturnsStringResult()
+    {
+      var raw = new FakeDriver { ScriptReturn = "abc" };
+      var driver = new PercyAppiumDriver(raw);
+
+      Assert.Equal("abc", driver.ExecuteScript("script"));
+    }
+
+    // Lines 197-205: private ExecuteScript returns null when no overload exists.
+    [Fact]
+    public void ExecuteDriverScript_ReturnsNull_WhenNoExecuteScriptOverload()
+    {
+      var raw = new NoExecuteScriptDriver();
+      var driver = new PercyAppiumDriver(raw);
+
+      Assert.Null(driver.ExecuteDriverScript("script"));
+    }
+
+    // Lines 72-80: getSessionId happy path (sessionId not null) returns it directly.
+    [Fact]
+    public void GetSessionId_ReturnsSessionId_WhenNotNull()
+    {
+      var raw = new FakeDriver { SessionIdValue = "session-xyz" };
+      var driver = new PercyAppiumDriver(raw);
+
+      Assert.Equal("session-xyz", driver.getSessionId());
+    }
+
+    // Lines 93-101: FindElementsByAccessibilityId returns a wrapped element.
+    [Fact]
+    public void FindElementsByAccessibilityId_ReturnsWrappedElement()
+    {
+      var raw = new FakeDriver();
+      var driver = new PercyAppiumDriver(raw);
+
+      var element = driver.FindElementsByAccessibilityId("some-id");
+
+      Assert.NotNull(element);
+      Assert.IsType<PercyAppiumElement>(element);
+      Assert.Equal("element_id", element.id);
+    }
+
+    // Lines 93-100 + 110: FindElementsByAccessibilityId returns null when no element.
+    [Fact]
+    public void FindElementsByAccessibilityId_ReturnsNull_WhenElementMissing()
+    {
+      var raw = new NullElementDriver();
+      var driver = new PercyAppiumDriver(raw);
+
+      Assert.Null(driver.FindElementsByAccessibilityId("missing"));
+    }
+
+    // Lines 103-111: FindElementByXPath returns a wrapped element.
+    [Fact]
+    public void FindElementByXPath_ReturnsWrappedElement()
+    {
+      var raw = new FakeDriver();
+      var driver = new PercyAppiumDriver(raw);
+
+      var element = driver.FindElementByXPath("//xpath");
+
+      Assert.NotNull(element);
+      Assert.IsType<PercyAppiumElement>(element);
+      Assert.Equal("element_id", element.id);
+    }
+
+    // Lines 103-106 + 110: FindElementByXPath returns null when no element.
+    [Fact]
+    public void FindElementByXPath_ReturnsNull_WhenElementMissing()
+    {
+      var raw = new NullElementDriver();
+      var driver = new PercyAppiumDriver(raw);
+
+      Assert.Null(driver.FindElementByXPath("//missing"));
+    }
+
+    // Lines 174-186 + 193: private FindElement logs and returns null when the
+    // driver lacks a matching FindElement(string,string) overload.
+    [Fact]
+    public void FindElement_ReturnsNull_WhenMethodMissing()
+    {
+      var raw = new NoFindElementDriver();
+      var driver = new PercyAppiumDriver(raw);
+
+      Assert.Null(driver.FindElementByXPath("//x"));
+      Assert.Null(driver.FindElementsByAccessibilityId("x"));
+    }
+
+    // Lines 174-181 + 188-193: private FindElement catch branch returns null
+    // when invoking FindElement throws.
+    [Fact]
+    public void FindElement_ReturnsNull_WhenInvocationThrows()
+    {
+      var raw = new ThrowingFindElementDriver();
+      var driver = new PercyAppiumDriver(raw);
+
+      Assert.Null(driver.FindElementByXPath("//x"));
+      Assert.Null(driver.FindElementsByAccessibilityId("x"));
+    }
+
+    // Lines 143-170 (GetHost) including 159-162: internalExecutor branch of GetHostV5.
+    [Fact]
+    public void GetHost_ResolvesUrl_ViaInternalExecutorBranch()
+    {
+      var raw = new InternalExecutorDriver("https://hub-cloud.browserstack.com/wd/hub");
+      var driver = new PercyAppiumDriver(raw);
+
+      var host = driver.GetHost();
+
+      Assert.Equal("https://hub-cloud.browserstack.com/wd/hub", host);
+    }
+  }
+}

--- a/Percy.Tests/metadata/AndroidMetadataTest.cs
+++ b/Percy.Tests/metadata/AndroidMetadataTest.cs
@@ -1,3 +1,5 @@
+using System;
+using System.Collections.Generic;
 using OpenQA.Selenium;
 using Moq;
 using Xunit;
@@ -126,6 +128,50 @@ namespace Percy.Tests
     {
       androidMetadata = new AndroidMetadata(_androidPercyAppiumDriver.Object, "Samsung_gs22u", 0, 100, null, null);
       Assert.Equal(androidMetadata.OsName(), "Android");
+    }
+
+    [Fact]
+    public void TestGetDeviceName_WhenNameAndDeviceCapAreNull_FallsBackToDesired()
+    {
+      // Arrange: name is null and the "device" capability is absent, so it should
+      // fall back to the "deviceName" entry under "desired" (AndroidMetadata lines 27-29)
+      var caps = new PercyAppiumCapabilities();
+      var desired = new Dictionary<string, object>(){
+        {"deviceName", "Pixel_6"}
+      };
+      caps.SetCapability(new Dictionary<string, object>(){
+        {"desired", desired}
+      });
+      var percyAppiumDriver = new Mock<IPercyAppiumDriver>();
+      percyAppiumDriver.Setup(x => x.GetCapabilities()).Returns(caps);
+      percyAppiumDriver.Setup(x => x.sessionId()).Returns("session-1");
+      var expected = "Pixel_6";
+      androidMetadata = new AndroidMetadata(percyAppiumDriver.Object, null, 0, 0, null, null);
+      // Act
+      var actual = androidMetadata.DeviceName();
+      // Assert
+      Assert.Equal(expected, actual);
+    }
+
+    [Fact]
+    public void TestGetDeviceName_WhenNameAndDeviceCapAreNull_AndDesiredHasNoDeviceName()
+    {
+      // Arrange: name null, no "device" cap, and "desired" lacks "deviceName"
+      // so TryGetValue fails and an empty string is returned (AndroidMetadata line 29 false branch)
+      var caps = new PercyAppiumCapabilities();
+      var desired = new Dictionary<string, object>();
+      caps.SetCapability(new Dictionary<string, object>(){
+        {"desired", desired}
+      });
+      var percyAppiumDriver = new Mock<IPercyAppiumDriver>();
+      percyAppiumDriver.Setup(x => x.GetCapabilities()).Returns(caps);
+      percyAppiumDriver.Setup(x => x.sessionId()).Returns("session-1");
+      var expected = "";
+      androidMetadata = new AndroidMetadata(percyAppiumDriver.Object, null, 0, 0, null, null);
+      // Act
+      var actual = androidMetadata.DeviceName();
+      // Assert
+      Assert.Equal(expected, actual);
     }
   }
 }

--- a/Percy.Tests/metadata/IosMetadataTest.cs
+++ b/Percy.Tests/metadata/IosMetadataTest.cs
@@ -6,14 +6,25 @@ using System.Collections.Generic;
 
 namespace Percy.Tests
 {
-  public class IosMetadataTest
+  public class IosMetadataTest : IDisposable
   {
     private IosMetadata iosMetadata;
     private readonly Mock<IPercyAppiumDriver> _iPhonePercyAppiumDriver = new Mock<IPercyAppiumDriver>();
 
+    // Several tests below replace the shared static MetadataHelper.ValueFromStaticDevicesInfo
+    // delegate with stubs. Capture the original and restore it after each test so the
+    // mutation does not leak into other test classes (e.g. MetadataHelperTest).
+    private readonly Func<string, string, int> _originalValueFromStaticDevicesInfo;
+
     public IosMetadataTest()
     {
       _iPhonePercyAppiumDriver = MetadataBuilder.mockDriver("iOS");
+      _originalValueFromStaticDevicesInfo = MetadataHelper.ValueFromStaticDevicesInfo;
+    }
+
+    public void Dispose()
+    {
+      MetadataHelper.ValueFromStaticDevicesInfo = _originalValueFromStaticDevicesInfo;
     }
 
     [Fact]

--- a/Percy.Tests/metadata/MetadataHelperTest.cs
+++ b/Percy.Tests/metadata/MetadataHelperTest.cs
@@ -1,0 +1,73 @@
+using System;
+using Moq;
+using Xunit;
+using PercyIO.Appium;
+namespace Percy.Tests
+{
+  public class MetadataHelperTest
+  {
+    [Fact]
+    public void TestResolve_ReturnsAndroidMetadata_WhenAndroidDriver()
+    {
+      // Arrange: driver class name contains "Android" (MetadataHelper lines 16-19)
+      Mock<IPercyAppiumDriver> _androidPercyAppiumDriver = MetadataBuilder.mockDriver("Android");
+      // Act
+      var metadata = MetadataHelper.Resolve(_androidPercyAppiumDriver.Object, "Samsung_gs22u", 100, 200, null, null);
+      // Assert
+      Assert.NotNull(metadata);
+      Assert.IsType<AndroidMetadata>(metadata);
+    }
+
+    [Fact]
+    public void TestResolve_ReturnsIosMetadata_WhenIosDriver()
+    {
+      // Arrange: driver class name contains "iOS" (MetadataHelper lines 21-23)
+      Mock<IPercyAppiumDriver> _iosPercyAppiumDriver = MetadataBuilder.mockDriver("iOS");
+      // Act
+      var metadata = MetadataHelper.Resolve(_iosPercyAppiumDriver.Object, "iPhone_11", 100, 200, null, null);
+      // Assert
+      Assert.NotNull(metadata);
+      Assert.IsType<IosMetadata>(metadata);
+    }
+
+    [Fact]
+    public void TestResolve_ReturnsNull_WhenUnsupportedDriver()
+    {
+      // Arrange: driver class name is neither Android nor iOS, so the else branch
+      // throws, is caught, logged, and null is returned
+      // (MetadataHelper lines 26, 27, 30, 31, 32, 33, 34)
+      Mock<IPercyAppiumDriver> _unknownPercyAppiumDriver = new Mock<IPercyAppiumDriver>();
+      _unknownPercyAppiumDriver.Setup(x => x.GetType()).Returns("Windows");
+      // Act
+      var metadata = MetadataHelper.Resolve(_unknownPercyAppiumDriver.Object, "device", 100, 200, null, null);
+      // Assert
+      Assert.Null(metadata);
+    }
+
+    [Fact]
+    public void TestValueFromStaticDevicesInfo_WhenDevicePresentInFile()
+    {
+      // Arrange: a device present in resources/devices.json should resolve the
+      // requested key from the embedded JSON, exercising the real delegate and
+      // GetDevicesJson (MetadataHelper lines 38, 39, 44, 48, 49, 50, 51, 52, 53, 54, 55, 56)
+      AppPercy.cache.Clear();
+      var expected = 44; // "iphone x" -> statusBarHeight
+      // Act
+      var actual = MetadataHelper.ValueFromStaticDevicesInfo("statusBarHeight", "iphone x");
+      // Assert
+      Assert.Equal(expected, actual);
+    }
+
+    [Fact]
+    public void TestValueFromStaticDevicesInfo_WhenDeviceAbsentInFile()
+    {
+      // Arrange: a device that is not present returns 0 (MetadataHelper lines 39, 40, 41, 42)
+      // Uses the cached JSON populated by the previous lookup as well as a fresh read.
+      var expected = 0;
+      // Act
+      var actual = MetadataHelper.ValueFromStaticDevicesInfo("statusBarHeight", "non_existent_device");
+      // Assert
+      Assert.Equal(expected, actual);
+    }
+  }
+}

--- a/Percy.Tests/metadata/MetadataTest.cs
+++ b/Percy.Tests/metadata/MetadataTest.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using OpenQA.Selenium.Appium.Android;
 using Moq;
 using Xunit;
@@ -114,6 +115,60 @@ namespace Percy.Tests
       String actual = metadata.PlatformVersion();
       // Assert
       Assert.Equal(actual, expected);
+    }
+
+    [Fact]
+    public void TestOrientaion_WhenOrientationIsNull_AndCapabilityIsPresent()
+    {
+      // Arrange: screenOrientation is null but the "orientation" capability is set,
+      // so it should be returned lower-cased (Metadata lines 59-62)
+      var caps = new PercyAppiumCapabilities();
+      caps.SetCapability(new Dictionary<string, object>(){
+        {"orientation", "LANDSCAPE"}
+      });
+      Mock<IPercyAppiumDriver> _androidPercyAppiumDriver = new Mock<IPercyAppiumDriver>();
+      _androidPercyAppiumDriver.Setup(x => x.GetCapabilities()).Returns(caps);
+      var metadata = new Mock<Metadata>(_androidPercyAppiumDriver.Object, "Android", 0, 0, null, null).Object;
+      var expected = "landscape";
+      // Act
+      var actual = metadata.Orientation();
+      // Assert
+      Assert.Equal(expected, actual);
+    }
+
+    [Fact]
+    public void TestPlatformVersion_WhenPlatformVersionMissing_FallsBackToOsVersion()
+    {
+      // Arrange: platVersion arg null and "platformVersion" cap absent, so it should
+      // fall back to the "os_version" capability (Metadata lines 80-81, 86)
+      var caps = new PercyAppiumCapabilities();
+      caps.SetCapability(new Dictionary<string, object>(){
+        {"os_version", "13"}
+      });
+      Mock<IPercyAppiumDriver> _androidPercyAppiumDriver = new Mock<IPercyAppiumDriver>();
+      _androidPercyAppiumDriver.Setup(x => x.GetCapabilities()).Returns(caps);
+      var metadata = new Mock<Metadata>(_androidPercyAppiumDriver.Object, "Android", 0, 0, null, null).Object;
+      String expected = "13";
+      // Act
+      String actual = metadata.PlatformVersion();
+      // Assert
+      Assert.Equal(expected, actual);
+    }
+
+    [Fact]
+    public void TestPlatformVersion_WhenBothPlatformVersionAndOsVersionMissing_ReturnsNull()
+    {
+      // Arrange: platVersion arg null and neither "platformVersion" nor "os_version"
+      // caps are present, so it should return null (Metadata lines 82-84)
+      var caps = new PercyAppiumCapabilities();
+      caps.SetCapability(new Dictionary<string, object>());
+      Mock<IPercyAppiumDriver> _androidPercyAppiumDriver = new Mock<IPercyAppiumDriver>();
+      _androidPercyAppiumDriver.Setup(x => x.GetCapabilities()).Returns(caps);
+      var metadata = new Mock<Metadata>(_androidPercyAppiumDriver.Object, "Android", 0, 0, null, null).Object;
+      // Act
+      String actual = metadata.PlatformVersion();
+      // Assert
+      Assert.Null(actual);
     }
   }
 }

--- a/Percy.Tests/providers/AppAutomateTest.cs
+++ b/Percy.Tests/providers/AppAutomateTest.cs
@@ -442,5 +442,146 @@ namespace Percy.Tests
       // Assert
       Assert.Equal(actual, expected);
     }
+
+    [Fact]
+    public void TestExecutePercyScreenshotBegin_WhenSessionNotMarked()
+    {
+      // Arrange — first begin returns success=false, flipping markedPercySession to false
+      var name = "First";
+      var failureResponse = JObject.FromObject(new { success = false });
+      _androidPercyAppiumDriver.Setup(x => x.ExecuteScript(It.IsAny<string>()))
+        .Returns(failureResponse.ToString());
+      var appAutomate = new AppAutomate(_androidPercyAppiumDriver.Object);
+      // First call marks the session as not a Percy session
+      appAutomate.ExecutePercyScreenshotBegin(name);
+      // Act — second call should skip the executor block and return null (covers line 60)
+      var result = appAutomate.ExecutePercyScreenshotBegin(name);
+      // Assert
+      Assert.Null(result);
+      _androidPercyAppiumDriver.Verify(x => x.ExecuteScript(It.IsAny<string>()), Times.Once);
+    }
+
+    [Fact]
+    public void TestExecutePercyScreenshotEnd_WhenSessionNotMarked()
+    {
+      // Arrange — begin returns success=false so markedPercySession becomes false
+      Environment.SetEnvironmentVariable("PERCY_LOGLEVEL", "debug");
+      var name = "First";
+      var failureResponse = JObject.FromObject(new { success = false });
+      _androidPercyAppiumDriver.Setup(x => x.ExecuteScript(It.IsAny<string>()))
+        .Returns(failureResponse.ToString());
+      var appAutomate = new AppAutomate(_androidPercyAppiumDriver.Object);
+      appAutomate.ExecutePercyScreenshotBegin(name);
+      // Act — end should skip the executor block and return null (covers line 99)
+      var result = appAutomate.ExecutePercyScreenshotEnd(name, "", false, null);
+      // Assert
+      Assert.Null(result);
+      _androidPercyAppiumDriver.Verify(x => x.ExecuteScript(It.IsAny<string>()), Times.Once);
+    }
+
+    [Fact]
+    public void TestScreenshot_WhenBaseScreenshotThrows()
+    {
+      // Arrange — begin succeeds (response has success + metadata fields) but the
+      // executor response has no "result" key, so ExecutePercyScreenshot (invoked from
+      // CaptureTiles inside base.Screenshot) throws, hitting the catch block (lines 125-128).
+      Environment.SetEnvironmentVariable("PERCY_DISABLE_REMOTE_UPLOADS", "false");
+      Environment.SetEnvironmentVariable("PERCY_LOGLEVEL", "debug");
+      var response = @"{success:'true', osVersion:'11.2', buildHash:'abc', sessionHash:'def', deviceName:'Samsung'}";
+      _androidPercyAppiumDriver.Setup(x => x.ExecuteScript(It.IsAny<string>()))
+        .Returns(response);
+      var appAutomate = new AppAutomate(_androidPercyAppiumDriver.Object);
+      var options = new ScreenshotOptions();
+      options.DeviceName = "Samsung";
+      options.StatusBarHeight = 100;
+      options.NavBarHeight = 100;
+      options.Orientation = "potrait";
+      options.FullScreen = false;
+      options.FullPage = true;
+      options.ScreenLengths = 2;
+      // Act + Assert — the exception is re-thrown after being captured for the end event
+      Assert.ThrowsAny<Exception>(() => appAutomate.Screenshot("temp", options));
+      Environment.SetEnvironmentVariable("PERCY_DISABLE_REMOTE_UPLOADS", "false");
+    }
+
+    [Fact]
+    public void TestCaptureTiles_WhenDisableRemoteUploadsAndFullPage()
+    {
+      // Arrange — remote uploads disabled + FullPage true logs a warning and falls back
+      // to base.CaptureTiles (covers lines 142-144).
+      Environment.SetEnvironmentVariable("PERCY_DISABLE_REMOTE_UPLOADS", "true");
+      Environment.SetEnvironmentVariable("PERCY_LOGLEVEL", "debug");
+      _androidPercyAppiumDriver.Setup(x => x.GetScreenshot())
+        .Returns("iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=");
+      _androidPercyAppiumDriver.Setup(x => x.GetHost())
+        .Returns("http://hub-cloud.browserstack.com/wd/hub");
+      var appAutomate = new AppAutomate(_androidPercyAppiumDriver.Object);
+      var metadata = new AndroidMetadata(_androidPercyAppiumDriver.Object, "Samsung Galaxy s22", 100, 200, null, null);
+      appAutomate.metadata = metadata;
+      var options = new ScreenshotOptions();
+      options.FullScreen = false;
+      options.FullPage = true;
+      options.ScreenLengths = 2;
+      // Act
+      var result = appAutomate.CaptureTiles(options);
+      // Assert — base.CaptureTiles returns a single tile
+      Assert.IsType<System.Collections.Generic.List<Tile>>(result);
+      Assert.Single(result);
+      Environment.SetEnvironmentVariable("PERCY_DISABLE_REMOTE_UPLOADS", "false");
+    }
+
+    [Fact]
+    public void TestCaptureTiles_WhenInvalidJsonThrows()
+    {
+      // Arrange — ExecutePercyScreenshot returns a non-array "result", so JArray.Parse
+      // throws and is wrapped into a new Exception (covers lines 156-159).
+      Environment.SetEnvironmentVariable("PERCY_DISABLE_REMOTE_UPLOADS", "false");
+      _androidPercyAppiumDriver.Setup(x => x.ExecuteScript(It.IsAny<string>()))
+        .Returns(JsonConvert.SerializeObject(new
+        {
+          success = true,
+          result = "not-a-json-array"
+        }));
+      var appAutomate = new AppAutomate(_androidPercyAppiumDriver.Object);
+      var metadata = new AndroidMetadata(_androidPercyAppiumDriver.Object, "Samsung Galaxy s22", 100, 200, null, null);
+      appAutomate.metadata = metadata;
+      var options = new ScreenshotOptions();
+      options.FullScreen = false;
+      options.FullPage = true;
+      options.ScreenLengths = 2;
+      // Act + Assert
+      var ex = Assert.Throws<Exception>(() => appAutomate.CaptureTiles(options));
+      Assert.Equal("Error", ex.Message);
+    }
+
+    [Fact]
+    public void TestExecutePercyScreenshot_WhenPercyDevEnabled()
+    {
+      // Arrange — PERCY_ENABLE_DEV switches projectId to "percy-dev" (covers lines 182-184)
+      Environment.SetEnvironmentVariable("PERCY_ENABLE_DEV", "true");
+      var response = JsonConvert.SerializeObject(new
+      {
+        success = true,
+        result = JsonConvert.SerializeObject(new List<object> {
+            new { sha = "abcd-1234", header_height = 50, footer_height = 30 }
+          })
+      });
+      string captured = null;
+      _androidPercyAppiumDriver.Setup(x => x.ExecuteScript(It.IsAny<string>()))
+        .Callback<string>(s => captured = s)
+        .Returns(response);
+      var options = new ScreenshotOptions();
+      options.ScreenLengths = 2;
+      options.ScrollableXpath = "xapth/dummy/scrollable";
+      // Act
+      var appAutomate = new AppAutomate(_androidPercyAppiumDriver.Object);
+      var metadata = new AndroidMetadata(_androidPercyAppiumDriver.Object, "Samsung Galaxy s22", 100, 200, null, null);
+      appAutomate.metadata = metadata;
+      var actual = appAutomate.ExecutePercyScreenshot(options);
+      // Assert — the request payload carries the dev project id
+      Assert.Contains("percy-dev", captured);
+      Assert.Contains("abcd-1234", actual);
+      Environment.SetEnvironmentVariable("PERCY_ENABLE_DEV", "false");
+    }
   }
 }

--- a/Percy.Tests/providers/GenericProviderTest.cs
+++ b/Percy.Tests/providers/GenericProviderTest.cs
@@ -192,5 +192,214 @@ namespace Percy.Tests
       // Assert
       Assert.Empty(elementsArray);
     }
+
+    // Targets GenericProvider.cs lines 34-38: the full-page fallback warning branch.
+    // The default mock driver's GetHost() is not a BrowserStack hub, so
+    // AppAutomate.Supports(...) is false and the warning log branch executes.
+    [Fact]
+    public void TestCaptureTile_FullPageOnNonAppAutomate_FallsBackToSinglePage()
+    {
+      // Arrange
+      AppPercy.cache.Clear();
+      _androidPercyAppiumDriver.Setup(x => x.GetHost())
+        .Returns("http://hub-cloud.abc.com/wd/hub");
+      var genericProvider = new GenericProvider(_androidPercyAppiumDriver.Object);
+      var metadata = MetadataHelper.Resolve(_androidPercyAppiumDriver.Object, "Samsung Galaxy s22", 100, 200, null, null);
+      genericProvider.metadata = metadata;
+      var options = new ScreenshotOptions();
+      options.FullScreen = false;
+      options.FullPage = true;
+      options.ScreenLengths = 0;
+      // Act
+      var tiles = genericProvider.CaptureTiles(options);
+      // Assert — falls back to a single tile despite FullPage being requested
+      Assert.Single(tiles);
+      Assert.True(tiles[0].LocalFilePath.EndsWith(".png"));
+      Assert.Equal(100, Convert.ToInt32(tiles[0].StatusBarHeight));
+      Assert.Equal(200, Convert.ToInt32(tiles[0].NavBarHeight));
+    }
+
+    // Targets lines 126-141 (RegionObject) and 146-154 (RegionsByXpath happy path).
+    // MockAppiumElement => Location (200,300), Size (100,200); Android ScaleFactor = 1.
+    [Fact]
+    public void TestRegionsByXpath_ValidElement_AddsRegionToElementsArray()
+    {
+      // Arrange
+      AppPercy.cache.Clear();
+      var element = new PercyAppiumElement(new MockAppiumElement());
+      _androidPercyAppiumDriver.Setup(x => x.FindElementByXPath(It.IsAny<string>()))
+        .Returns(element);
+      var genericProvider = new GenericProvider(_androidPercyAppiumDriver.Object);
+      var metadata = MetadataHelper.Resolve(_androidPercyAppiumDriver.Object, "Samsung Galaxy s22", 100, 200, null, null);
+      genericProvider.metadata = metadata;
+      var elementsArray = new JArray();
+      var xpaths = new List<string> { "//android.widget.Button" };
+      // Act
+      genericProvider.RegionsByXpath(elementsArray, xpaths);
+      // Assert
+      Assert.Single(elementsArray);
+      var region = elementsArray[0];
+      Assert.Equal("xpath: //android.widget.Button", region["selector"].ToObject<string>());
+      var coordinates = region["co_ordinates"];
+      Assert.Equal(300, coordinates["top"].ToObject<int>());     // location.Y
+      Assert.Equal(500, coordinates["bottom"].ToObject<int>());  // location.Y + size.Height
+      Assert.Equal(200, coordinates["left"].ToObject<int>());    // location.X
+      Assert.Equal(300, coordinates["right"].ToObject<int>());   // location.X + size.Width
+    }
+
+    // Targets lines 156-160: RegionsByXpath catch block (FindElementByXPath throws).
+    [Fact]
+    public void TestRegionsByXpath_ElementNotFound_SkipsXpath()
+    {
+      // Arrange
+      AppPercy.cache.Clear();
+      _androidPercyAppiumDriver.Setup(x => x.FindElementByXPath(It.IsAny<string>()))
+        .Throws(new Exception("element not found"));
+      var genericProvider = new GenericProvider(_androidPercyAppiumDriver.Object);
+      var metadata = MetadataHelper.Resolve(_androidPercyAppiumDriver.Object, "Samsung Galaxy s22", 100, 200, null, null);
+      genericProvider.metadata = metadata;
+      var elementsArray = new JArray();
+      var xpaths = new List<string> { "//does/not/exist" };
+      // Act
+      genericProvider.RegionsByXpath(elementsArray, xpaths);
+      // Assert — missing element is ignored, nothing added
+      Assert.Empty(elementsArray);
+    }
+
+    // Targets lines 166-174: RegionsByIds happy path (and RegionObject again).
+    [Fact]
+    public void TestRegionsByIds_ValidElement_AddsRegionToElementsArray()
+    {
+      // Arrange
+      AppPercy.cache.Clear();
+      var element = new PercyAppiumElement(new MockAppiumElement());
+      _androidPercyAppiumDriver.Setup(x => x.FindElementsByAccessibilityId(It.IsAny<string>()))
+        .Returns(element);
+      var genericProvider = new GenericProvider(_androidPercyAppiumDriver.Object);
+      var metadata = MetadataHelper.Resolve(_androidPercyAppiumDriver.Object, "Samsung Galaxy s22", 100, 200, null, null);
+      genericProvider.metadata = metadata;
+      var elementsArray = new JArray();
+      var ids = new List<string> { "submit_button" };
+      // Act
+      genericProvider.RegionsByIds(elementsArray, ids);
+      // Assert
+      Assert.Single(elementsArray);
+      var region = elementsArray[0];
+      Assert.Equal("id: submit_button", region["selector"].ToObject<string>());
+      var coordinates = region["co_ordinates"];
+      Assert.Equal(300, coordinates["top"].ToObject<int>());
+      Assert.Equal(500, coordinates["bottom"].ToObject<int>());
+      Assert.Equal(200, coordinates["left"].ToObject<int>());
+      Assert.Equal(300, coordinates["right"].ToObject<int>());
+    }
+
+    // Targets lines 176-180: RegionsByIds catch block.
+    [Fact]
+    public void TestRegionsByIds_ElementNotFound_SkipsId()
+    {
+      // Arrange
+      AppPercy.cache.Clear();
+      _androidPercyAppiumDriver.Setup(x => x.FindElementsByAccessibilityId(It.IsAny<string>()))
+        .Throws(new Exception("element not found"));
+      var genericProvider = new GenericProvider(_androidPercyAppiumDriver.Object);
+      var metadata = MetadataHelper.Resolve(_androidPercyAppiumDriver.Object, "Samsung Galaxy s22", 100, 200, null, null);
+      genericProvider.metadata = metadata;
+      var elementsArray = new JArray();
+      var ids = new List<string> { "missing_id" };
+      // Act
+      genericProvider.RegionsByIds(elementsArray, ids);
+      // Assert
+      Assert.Empty(elementsArray);
+    }
+
+    // Targets lines 186-195: RegionsByElements happy path. MockAppiumElement.Type()
+    // (GetAttribute("class")) returns "Button"; selector => "element: 0 Button".
+    [Fact]
+    public void TestRegionsByElements_ValidElement_AddsRegionToElementsArray()
+    {
+      // Arrange
+      AppPercy.cache.Clear();
+      var genericProvider = new GenericProvider(_androidPercyAppiumDriver.Object);
+      var metadata = MetadataHelper.Resolve(_androidPercyAppiumDriver.Object, "Samsung Galaxy s22", 100, 200, null, null);
+      genericProvider.metadata = metadata;
+      var elementsArray = new JArray();
+      var elements = new List<object> { new MockAppiumElement() };
+      // Act
+      genericProvider.RegionsByElements(elementsArray, elements);
+      // Assert
+      Assert.Single(elementsArray);
+      var region = elementsArray[0];
+      Assert.Equal("element: 0 Button", region["selector"].ToObject<string>());
+      var coordinates = region["co_ordinates"];
+      Assert.Equal(300, coordinates["top"].ToObject<int>());
+      Assert.Equal(500, coordinates["bottom"].ToObject<int>());
+      Assert.Equal(200, coordinates["left"].ToObject<int>());
+      Assert.Equal(300, coordinates["right"].ToObject<int>());
+    }
+
+    // Targets lines 197-201: RegionsByElements catch block. A non-element object
+    // (no Location/Size/GetAttribute) makes PercyAppiumElement construction throw.
+    [Fact]
+    public void TestRegionsByElements_InvalidElement_SkipsElement()
+    {
+      // Arrange
+      AppPercy.cache.Clear();
+      var genericProvider = new GenericProvider(_androidPercyAppiumDriver.Object);
+      var metadata = MetadataHelper.Resolve(_androidPercyAppiumDriver.Object, "Samsung Galaxy s22", 100, 200, null, null);
+      genericProvider.metadata = metadata;
+      var elementsArray = new JArray();
+      var elements = new List<object> { "not an appium element" };
+      // Act
+      genericProvider.RegionsByElements(elementsArray, elements);
+      // Assert — invalid element at index 0 is ignored
+      Assert.Empty(elementsArray);
+    }
+
+    // Targets lines 236-240: RegionsByLocation catch block. A null entry makes
+    // customLocations[index].IsValid(...) throw a NullReferenceException.
+    [Fact]
+    public void TestRegionsByLocation_ThrowingLocation_SkipsAndContinues()
+    {
+      // Arrange
+      AppPercy.cache.Clear();
+      var elementsArray = new JArray();
+      var customLocations = new List<Region> { null };
+      var genericProvider = new GenericProvider(_androidPercyAppiumDriver.Object);
+      var metadata = MetadataHelper.Resolve(_androidPercyAppiumDriver.Object, "Samsung Galaxy s22", 100, 200, null, null);
+      genericProvider.metadata = metadata;
+      // Act — should swallow the exception and not add anything
+      genericProvider.RegionsByLocation(elementsArray, customLocations);
+      // Assert
+      Assert.Empty(elementsArray);
+    }
+
+    // Targets the FindRegions aggregation path (lines 115-123) end-to-end:
+    // xpath + accessibility id + appium element + custom location combine into one array.
+    [Fact]
+    public void TestFindRegions_AggregatesAllRegionTypes()
+    {
+      // Arrange
+      AppPercy.cache.Clear();
+      var element = new PercyAppiumElement(new MockAppiumElement());
+      _androidPercyAppiumDriver.Setup(x => x.FindElementByXPath(It.IsAny<string>()))
+        .Returns(element);
+      _androidPercyAppiumDriver.Setup(x => x.FindElementsByAccessibilityId(It.IsAny<string>()))
+        .Returns(element);
+      var genericProvider = new GenericProvider(_androidPercyAppiumDriver.Object);
+      var metadata = MetadataHelper.Resolve(_androidPercyAppiumDriver.Object, "Samsung Galaxy s22", 100, 200, null, null);
+      genericProvider.metadata = metadata;
+      var xpaths = new List<string> { "//android.widget.Button" };
+      var ids = new List<string> { "submit_button" };
+      var appiumElements = new List<object> { new MockAppiumElement() };
+      var locations = new List<Region> { new Region(10, 100, 20, 200) };
+      // Act
+      var regions = genericProvider.FindRegions(xpaths, ids, appiumElements, locations);
+      // Assert — one region from each of the four sources
+      Assert.Equal(4, regions.Count);
+      Assert.Equal("xpath: //android.widget.Button", regions[0]["selector"].ToObject<string>());
+      Assert.Equal("id: submit_button", regions[1]["selector"].ToObject<string>());
+      Assert.Equal("element: 0 Button", regions[2]["selector"].ToObject<string>());
+      Assert.Equal("custom region 0", regions[3]["selector"].ToObject<string>());
+    }
   }
 }

--- a/Percy.Tests/utils/PercyExceptionTest.cs
+++ b/Percy.Tests/utils/PercyExceptionTest.cs
@@ -1,0 +1,33 @@
+using System;
+using Xunit;
+
+namespace Percy.Tests
+{
+  public class PercyExceptionTests
+  {
+    [Fact]
+    public void Constructor_WithMessage_SetsMessage()
+    {
+      // Act
+      var exception = new PercyException("something went wrong");
+
+      // Assert
+      Assert.Equal("something went wrong", exception.Message);
+      Assert.Null(exception.InnerException);
+    }
+
+    [Fact]
+    public void Constructor_WithMessageAndInnerException_SetsBoth()
+    {
+      // Arrange
+      var inner = new Exception("inner cause");
+
+      // Act
+      var exception = new PercyException("outer message", inner);
+
+      // Assert
+      Assert.Equal("outer message", exception.Message);
+      Assert.Same(inner, exception.InnerException);
+    }
+  }
+}

--- a/Percy.Tests/utils/UtilsTest.cs
+++ b/Percy.Tests/utils/UtilsTest.cs
@@ -1,0 +1,41 @@
+using Xunit;
+using PercyIO.Appium;
+
+namespace Percy.Tests
+{
+  public class UtilsTest
+  {
+    [Fact]
+    public void IsValidDriverObject_ReturnsTrue_ForSupportedDriverType()
+    {
+      // Arrange — type whose full name contains a supported Appium driver classname
+      var driver = new OpenQA.Selenium.Appium.Android.AndroidDriverStub();
+
+      // Act
+      bool actual = Utils.isValidDriverObject(driver);
+
+      // Assert
+      Assert.True(actual);
+    }
+
+    [Fact]
+    public void IsValidDriverObject_ReturnsFalse_ForUnsupportedDriverType()
+    {
+      // Act
+      bool actual = Utils.isValidDriverObject("just a string");
+
+      // Assert
+      Assert.False(actual);
+    }
+  }
+}
+
+namespace OpenQA.Selenium.Appium.Android
+{
+  // Full name "OpenQA.Selenium.Appium.Android.AndroidDriverStub" contains the supported
+  // classname "OpenQA.Selenium.Appium.Android.AndroidDriver" from Utils.SupportedDriverClassnames,
+  // exercising the isValidDriverObject true branch without depending on a real Appium driver.
+  internal class AndroidDriverStub
+  {
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "scripts": {
-    "test": "percy exec --testing -- dotnet test"
+    "test": "percy exec --testing -- dotnet test /p:CollectCoverage=true /p:CoverletOutputFormat=cobertura /p:ThresholdType=line /p:Threshold=99"
   },
   "devDependencies": {
     "@percy/cli": "^1.28.0"


### PR DESCRIPTION
## What & why

The `coverlet.collector` package was present but **unwired** (coverage measured by nobody, no enforcement) and the SDK sat at **82.4%** line. This PR turns coverlet on with a **99% line-coverage gate** and adds meaningful unit tests across the SDK.

> **82.4% → 99.42% line** (89.8% branch), **104 → 159 tests**, all green. No coverlet `excludes` — every counted line is covered by a real test.

## Gate

- Added `coverlet.msbuild`; the `npm test` script now runs `dotnet test /p:CollectCoverage=true /p:ThresholdType=line /p:Threshold=99`. The Test workflow already runs `npm test`, so **the build now fails if line coverage drops below 99%** — no CI yaml change needed.

## Tests added / extended

| Area | Coverage |
|------|----------|
| **`GenericProvider`** | region helpers (xpath/id/element/location — valid + catch), full-page fallback, `FindRegions` aggregation, debug url |
| **`PercyAppiumDriver`** (new test file, was untested) | delegating methods: orientation, downscaled width, execute(driver)script, getSessionId, find element(s) by accessibility-id/xpath, `GetHost` executor branch |
| **`AppAutomate` / `PercyOnAutomate`** | begin/end marked-session branches, capture-tiles disable-uploads + invalid-json, percy-dev project, ignore/consider region elements, exception paths |
| **`AppPercy`** | disabled-in-caps, data-key response, error swallow + rethrow |
| **`MetadataHelper`** (new) **/ `Metadata` / `AndroidMetadata`** | resolver branches, unsupported-driver throw, device-info lookup, platform/orientation fallbacks |
| **`Env` / `Utils` / `Percy` / `PercyException` / `Region`** | setters, valid-driver check, ctor early-return, exception ctor, region-validity branch |

## Test-isolation fix

`IosMetadataTest` replaced the shared static `MetadataHelper.ValueFromStaticDevicesInfo` delegate without restoring it, leaking into other test classes and causing order-dependent failures. Made it `IDisposable` and restore the original after each test — verified stable across repeated full runs.

## The gap (honest note)

7 lines remain uncovered, genuinely not unit-testable: the `Utils` debug-log branch (gated by a `static readonly DEBUG` read from `PERCY_LOGLEVEL` at type load — `initonly`, can't be flipped at runtime) and `PercyAppiumDriver.getSessionId`'s dynamic null-fallback. The 99% gate accounts for these; nothing is excluded.

## Verification

```
npm test  →  Passed! 159, Failed: 0
coverage  →  Total Line 99.42% | Branch 89.82% | Method 100%
gate (/p:Threshold=99 line)  →  exit 0
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)