### PR TITLE
Release 3.0.9-beta.3

### DIFF
--- a/Percy/Percy.csproj
+++ b/Percy/Percy.csproj
@@ -9,7 +9,7 @@
     <PackageId>PercyIO.Appium</PackageId>
     <Description>An App Percy SDK for Appium WebDriver API .NET Bindings</Description>
     <PackageTags>appium;percy;visual;testing</PackageTags>
-    <Version>3.0.9-beta.2</Version>
+    <Version>3.0.9-beta.3</Version>
     <Company>Perceptual Inc</Company>
     <Copyright>Copyright Perceptual Inc</Copyright>
     <Authors>percy-admin</Authors>


### PR DESCRIPTION
Version bump to **3.0.9-beta.3** for the Appium version-compatibility work (PER-7786, #392).

- `Percy/Percy.csproj`: 3.0.9-beta.2 → 3.0.9-beta.3

🤖 Generated with [Claude Code](https://claude.com/claude-code)