### PR TITLE
release v3.0.10-beta.1

### DIFF
--- a/Percy.Tests/AppPercyTest.cs
+++ b/Percy.Tests/AppPercyTest.cs
@@ -10,10 +10,19 @@ using System.IO;
 
 namespace Percy.Tests
 {
-  public class AppPercyTest
+  public class AppPercyTest : IDisposable
   {
     private readonly MockDriverObject mockDriver;
     private readonly StringWriter stringWriter;
+
+    // Reset shared static state after every test so the mock HttpClient and the
+    // PERCY_DISABLE_REMOTE_UPLOADS env var set here cannot leak into other test
+    // classes (cross-class test pollution).
+    public void Dispose()
+    {
+      CliWrapper.resetHttpClient();
+      Environment.SetEnvironmentVariable("PERCY_DISABLE_REMOTE_UPLOADS", null);
+    }
 
     public AppPercyTest()
     {

--- a/Percy.Tests/PercyOnAutomateTest.cs
+++ b/Percy.Tests/PercyOnAutomateTest.cs
@@ -10,14 +10,27 @@ using Newtonsoft.Json.Linq;
 
 namespace Percy.Tests
 {
-  public class PercyOnAutomateTest
+  public class PercyOnAutomateTest : IDisposable
   {
     private readonly MockDriverObject mockDriver;
     private readonly StringWriter stringWriter;
     private readonly MockHttpMessageHandler mockHttp;
 
+    // Reset the static HttpClient after every test so a mock handler set here
+    // cannot leak into subsequent test classes (cross-class test pollution).
+    public void Dispose()
+    {
+      CliWrapper.resetHttpClient();
+    }
+
     public PercyOnAutomateTest()
     {
+      // PercyAppiumDriver.GetCapabilities() caches the capabilities object in the
+      // static AppPercy.cache keyed by sessionId ("caps_session-1"). Every test
+      // reuses "session-1", so a capabilities object cached by a previously-run
+      // test class would be reused here and produce the wrong request body,
+      // breaking the WithPartialContent matchers. Clear it like AppPercyTest does.
+      AppPercy.cache.Clear();
       mockDriver = new MockDriverObject();
       mockDriver.SessionId = "session-1";
       CliWrapper.Healthcheck = () =>

--- a/Percy.Tests/PercyTest.cs
+++ b/Percy.Tests/PercyTest.cs
@@ -12,11 +12,23 @@ using OpenQA.Selenium.Support.UI;
 
 namespace Percy.Tests
 {
-  public class PercyTest
+  public class PercyTest : IDisposable
   {
     private readonly MockDriverObject mockDriver;
+
+    // Reset the static HttpClient after every test so a mock handler set here
+    // cannot leak into subsequent test classes (cross-class test pollution).
+    public void Dispose()
+    {
+      CliWrapper.resetHttpClient();
+    }
+
     public PercyTest()
     {
+      // The AppPercy.cache is static and keyed by sessionId. Tests across classes
+      // all reuse "session-1", so a cached (possibly percy-disabled) PercyOptions
+      // entry can leak in and short-circuit Screenshot. Clear it like AppPercyTest does.
+      AppPercy.cache.Clear();
       mockDriver = new MockDriverObject();
       mockDriver.SessionId = "session-1";
       var mockHttp = new MockHttpMessageHandler();

--- a/Percy.Tests/providers/AppAutomateTest.cs
+++ b/Percy.Tests/providers/AppAutomateTest.cs
@@ -11,13 +11,22 @@ using System.Net.Http;
 
 namespace Percy.Tests
 {
-  public class AppAutomateTest
+  public class AppAutomateTest : IDisposable
   {
     private readonly Mock<IPercyAppiumDriver> _androidPercyAppiumDriver = new Mock<IPercyAppiumDriver>();
 
     public AppAutomateTest()
     {
       _androidPercyAppiumDriver = MetadataBuilder.mockDriver("Android");
+    }
+
+    // Reset shared static state after every test so the mock HttpClient and the
+    // PERCY_DISABLE_REMOTE_UPLOADS env var set here cannot leak into other test
+    // classes (cross-class test pollution).
+    public void Dispose()
+    {
+      CliWrapper.resetHttpClient();
+      Environment.SetEnvironmentVariable("PERCY_DISABLE_REMOTE_UPLOADS", null);
     }
 
     [Fact]
@@ -130,10 +139,19 @@ namespace Percy.Tests
       options.ScreenLengths = 0;
 
       AppAutomate appAutomate = new AppAutomate(_androidPercyAppiumDriver.Object);
+
+      // Set up an explicit mock for the comparison endpoint so this test does not
+      // depend on a leaked static HttpClient from a previously-executed test class.
+      var mockHttp = new MockHttpMessageHandler();
+      mockHttp.When("http://localhost:5338/percy/comparison")
+        .Respond("application/json", "{\"success\": true}");
+      CliWrapper.setHttpClient(new HttpClient(mockHttp));
+
       // Act
       var actual = appAutomate.Screenshot("temp", options);
       // Assert
       Assert.Equal(true, actual["success"]);
+      CliWrapper.resetHttpClient();
       Environment.SetEnvironmentVariable("PERCY_DISABLE_REMOTE_UPLOADS", "false");
     }
 

--- a/Percy/Percy.csproj
+++ b/Percy/Percy.csproj
@@ -9,7 +9,7 @@
     <PackageId>PercyIO.Appium</PackageId>
     <Description>An App Percy SDK for Appium WebDriver API .NET Bindings</Description>
     <PackageTags>appium;percy;visual;testing</PackageTags>
-    <Version>3.0.9</Version>
+    <Version>3.0.10-beta.1</Version>
     <Company>Perceptual Inc</Company>
     <Copyright>Copyright Perceptual Inc</Copyright>
     <Authors>percy-admin</Authors>


### PR DESCRIPTION
Bumps the SDK to the next beta (`3.0.9` → `3.0.10-beta.1`) for a beta release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)