### PR TITLE
ci: run tests against an unpublished @percy/cli branch (PER-9772)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,6 +4,11 @@ on:
     branches: [master]
   pull_request:
   workflow_dispatch:
+    inputs:
+      branch:
+        description: Which branch of @percy/cli to build from source for this run
+        required: false
+        default: master
 jobs:
   test:
     name: Test
@@ -34,5 +39,35 @@ jobs:
           PERCY_POSTINSTALL_BROWSER: true
       - name: Build Package
         run: dotnet build --configuration Release --no-restore
+      # Optionally run against an unpublished @percy/cli branch (workflow_dispatch).
+      # npm test runs `percy exec --testing -- dotnet test`, so the built CLI on
+      # PATH is actually exercised. Branch is env-passed + regex-validated.
+      - uses: actions-ecosystem/action-regex-match@v2
+        id: regex-match
+        if: ${{ github.event_name == 'workflow_dispatch' }}
+        with:
+          text: ${{ github.event.inputs.branch }}
+          regex: '^[a-zA-Z0-9_/\-]+$'
+      - name: Break on invalid branch name
+        if: ${{ github.event_name == 'workflow_dispatch' && steps.regex-match.outputs && steps.regex-match.outputs.match == '' }}
+        run: exit 1
+      - name: Set up @percy/cli from git
+        if: ${{ github.event_name == 'workflow_dispatch' }}
+        env:
+          BRANCH: ${{ github.event.inputs.branch }}
+          WORKSPACE: ${{ github.workspace }}
+        run: |
+          cd /tmp
+          git clone --branch "$BRANCH" --depth 1 https://github.com/percy/cli
+          cd cli
+          PERCY_PACKAGES=`find packages -mindepth 1 -maxdepth 1 -type d | sed -e 's/packages/@percy/g' | tr '\n' ' '`
+          yarn
+          yarn build
+          yarn global:link
+          cd "$WORKSPACE"
+          yarn link $PERCY_PACKAGES >/dev/null 2>&1 || true
+          echo "$(yarn global bin)" >> "$GITHUB_PATH"
+          export PATH="$(yarn global bin):$PATH"
+          percy --version
       - name: Run Tests
         run: npm test -- --no-restore


### PR DESCRIPTION
Adds CLI-branch injection so percy-appium-dotnet runs against an unpublished `@percy/cli` branch. `npm test` = `percy exec --testing -- dotnet test`, so the built CLI on PATH is genuinely exercised (no device needed). Branch env-passed + regex-validated. Part of PER-9772. 🤖 Generated with [Claude Code](https://claude.com/claude-code)