### PR TITLE
fix: fullpage KeyNotFoundException on missing appiumVersion, plus the swallowed-exception logging that hid it (PER-10219)

### DIFF
--- a/Percy.Tests/AppPercyTest.cs
+++ b/Percy.Tests/AppPercyTest.cs
@@ -65,6 +65,36 @@ namespace Percy.Tests
     }
 
     [Fact]
+    public void TestScreenshot_LogsTheExceptionDetail_WhenSwallowed()
+    {
+      // PER-10219 — Screenshot() swallows and returns null, and percy-api redacts the message
+      // it receives from PostFailedEvent. If this log line does not name the exception, the
+      // failure becomes invisible to everyone downstream.
+      // /dev/null is a character device, so creating a directory under it fails on both
+      // Linux and macOS — a deterministic throw from inside Screenshot's try block.
+      Environment.SetEnvironmentVariable("PERCY_TMP_DIR", "/dev/null/nope");
+      try
+      {
+        mockDriver.SetCapability(MetadataBuilder.CapabilityBuilder("Android"));
+        mockDriver.setCommandExecutor("https://browserstack.com/wd/hub");
+
+        var name = "dummyName";
+        AppPercy appPercy = new AppPercy(mockDriver);
+        var result = appPercy.Screenshot(name, null);
+
+        var output = stringWriter.ToString();
+        Assert.Null(result);
+        // The exception type and message must both survive to the log — a bare
+        // "Error taking screenshot <name>" is what made PER-10219 undiagnosable.
+        Assert.Matches($@"Error taking screenshot {name} - \w*Exception: .+", output);
+      }
+      finally
+      {
+        Environment.SetEnvironmentVariable("PERCY_TMP_DIR", null);
+      }
+    }
+
+    [Fact]
     public void TestName_WithIOS_V4()
     {
       // Arrange

--- a/Percy.Tests/providers/AppAutomateTest.cs
+++ b/Percy.Tests/providers/AppAutomateTest.cs
@@ -708,7 +708,9 @@ namespace Percy.Tests
       options.ScreenLengths = 2;
       // Act + Assert
       var ex = Assert.Throws<Exception>(() => appAutomate.CaptureTiles(options));
-      Assert.Equal("Error", ex.Message);
+      // The message must identify the stage that failed, not just say "Error"
+      Assert.Contains("percyScreenshot executor", ex.Message);
+      Assert.NotNull(ex.InnerException);
     }
 
     [Fact]

--- a/Percy.Tests/providers/AppAutomateTest.cs
+++ b/Percy.Tests/providers/AppAutomateTest.cs
@@ -496,6 +496,27 @@ namespace Percy.Tests
     }
 
     [Fact]
+    public void TestVerifyCorrectAppiumVersion_WhenCapabilityLookupThrows()
+    {
+      // Version detection must not be able to take the screenshot down with it
+      _androidPercyAppiumDriver.Setup(x => x.GetCapabilities()).Throws(new Exception("caps unavailable"));
+      // Act
+      var appAutomate = new AppAutomate(_androidPercyAppiumDriver.Object);
+      var actual = appAutomate.VerifyCorrectAppiumVersion();
+      // Assert — falls back to single page instead of propagating
+      Assert.False(actual);
+    }
+
+    [Fact]
+    public void TestAppiumVersionCheck_WhenVersionIsEmpty()
+    {
+      var appAutomate = new AppAutomate(_androidPercyAppiumDriver.Object);
+      Assert.False(appAutomate.AppiumVersionCheck(null));
+      Assert.False(appAutomate.AppiumVersionCheck(""));
+      Assert.False(appAutomate.AppiumVersionCheck("   "));
+    }
+
+    [Fact]
     public void TestAppiumVersionCheck_AcrossMajors()
     {
       var appAutomate = new AppAutomate(_androidPercyAppiumDriver.Object);

--- a/Percy.Tests/providers/AppAutomateTest.cs
+++ b/Percy.Tests/providers/AppAutomateTest.cs
@@ -479,6 +479,37 @@ namespace Percy.Tests
     }
 
     [Fact]
+    public void TestVerifyCorrectAppiumVersion_WhenAppiumThree()
+    {
+      // PER-10219 — the gate is "Appium >= 1.19", but it was written as `major == 2` before 3.x
+      // existed, so a pinned `appiumVersion: 3.1.0` silently downgraded fullpage to single page.
+      _androidPercyAppiumDriver.Setup(x => x.GetCapabilities().getValue<Dictionary<string, object>>("bstack:options")).Returns(
+        new Dictionary<string, object> {
+          {"appiumVersion", "3.1.0"},
+        }
+      );
+      // Act
+      var appAutomate = new AppAutomate(_androidPercyAppiumDriver.Object);
+      var actual = appAutomate.VerifyCorrectAppiumVersion();
+      // Assert
+      Assert.True(actual);
+    }
+
+    [Fact]
+    public void TestAppiumVersionCheck_AcrossMajors()
+    {
+      var appAutomate = new AppAutomate(_androidPercyAppiumDriver.Object);
+      // Below the 1.19 floor
+      Assert.False(appAutomate.AppiumVersionCheck("1.18.0"));
+      // The floor and everything above it, including majors that did not exist when
+      // the check was written
+      Assert.True(appAutomate.AppiumVersionCheck("1.19.0"));
+      Assert.True(appAutomate.AppiumVersionCheck("2.0.0"));
+      Assert.True(appAutomate.AppiumVersionCheck("3.1.0"));
+      Assert.True(appAutomate.AppiumVersionCheck("4.0.0"));
+    }
+
+    [Fact]
     public void TestVerifyCorrectAppiumVersion_WhenMajorOnlyVersion()
     {
       // "appiumVersion: 2" is a legal pin — a missing minor must not throw IndexOutOfRange

--- a/Percy.Tests/providers/AppAutomateTest.cs
+++ b/Percy.Tests/providers/AppAutomateTest.cs
@@ -444,6 +444,111 @@ namespace Percy.Tests
     }
 
     [Fact]
+    public void TestVerifyCorrectAppiumVersion_WhenW3CWithoutAppiumVersionKey()
+    {
+      // PER-10219 — `bstack:options` is always injected on a BrowserStack SDK session, but
+      // `appiumVersion` is only in it when the user pins one. Indexing the missing key threw
+      // KeyNotFoundException, which propagated all the way out as a silent null screenshot.
+      _androidPercyAppiumDriver.Setup(x => x.GetCapabilities().getValue<Dictionary<string, object>>("bstack:options")).Returns(
+        new Dictionary<string, object> {
+          {"userName", "someuser"},
+          {"deviceName", "Samsung Galaxy S22"},
+          {"osVersion", "12.0"},
+        }
+      );
+      // Act
+      var appAutomate = new AppAutomate(_androidPercyAppiumDriver.Object);
+      var actual = appAutomate.VerifyCorrectAppiumVersion();
+      // Assert — unknown version must not block fullpage, and must not throw
+      Assert.True(actual);
+    }
+
+    [Fact]
+    public void TestVerifyCorrectAppiumVersion_WhenW3CAppiumVersionIsNull()
+    {
+      _androidPercyAppiumDriver.Setup(x => x.GetCapabilities().getValue<Dictionary<string, object>>("bstack:options")).Returns(
+        new Dictionary<string, object> {
+          {"appiumVersion", null},
+        }
+      );
+      // Act
+      var appAutomate = new AppAutomate(_androidPercyAppiumDriver.Object);
+      var actual = appAutomate.VerifyCorrectAppiumVersion();
+      // Assert
+      Assert.True(actual);
+    }
+
+    [Fact]
+    public void TestVerifyCorrectAppiumVersion_WhenMajorOnlyVersion()
+    {
+      // "appiumVersion: 2" is a legal pin — a missing minor must not throw IndexOutOfRange
+      _androidPercyAppiumDriver.Setup(x => x.GetCapabilities().getValue<Dictionary<string, object>>("bstack:options")).Returns(
+        new Dictionary<string, object> {
+          {"appiumVersion", "2"},
+        }
+      );
+      // Act
+      var appAutomate = new AppAutomate(_androidPercyAppiumDriver.Object);
+      var actual = appAutomate.VerifyCorrectAppiumVersion();
+      // Assert
+      Assert.True(actual);
+    }
+
+    [Fact]
+    public void TestVerifyCorrectAppiumVersion_WhenVersionIsUnparseable()
+    {
+      _androidPercyAppiumDriver.Setup(x => x.GetCapabilities().getValue<String>("browserstack.appium_version")).Returns("not-a-version");
+      // Act
+      var appAutomate = new AppAutomate(_androidPercyAppiumDriver.Object);
+      var actual = appAutomate.VerifyCorrectAppiumVersion();
+      // Assert — falls back to single page rather than throwing
+      Assert.False(actual);
+    }
+
+    [Fact]
+    public void TestExecutePercyScreenshot_FullPageWhenW3CWithoutAppiumVersionKey()
+    {
+      // PER-10219 end-to-end regression: FullPage=true + ScreenLengths>=2 is the only path that
+      // evaluates VerifyCorrectAppiumVersion(), which is why FullPage=false kept working while
+      // fullpage silently produced no snapshot at all.
+      Environment.SetEnvironmentVariable("PERCY_DISABLE_REMOTE_UPLOADS", "false");
+      // Real capability lookup (not a stubbed getValue) so the missing-key path is genuinely
+      // exercised — `bstack:options` present, `appiumVersion` absent, as the BrowserStack SDK
+      // sends it whenever the user has not pinned a version.
+      var caps = new PercyAppiumCapabilities();
+      var capsDict = MetadataBuilder.CapabilityBuilder("Android");
+      capsDict.Add("bstack:options", new Dictionary<string, object> {
+        {"userName", "someuser"},
+        {"deviceName", "Samsung Galaxy S22"},
+      });
+      caps.SetCapability(capsDict);
+      _androidPercyAppiumDriver.Setup(x => x.GetCapabilities()).Returns(caps);
+      var response = JsonConvert.SerializeObject(new
+      {
+        success = true,
+        result = JsonConvert.SerializeObject(new List<object> {
+            new { sha = "abcd-1234", header_height = 50, footer_height = 30 }
+          })
+      });
+      string captured = null;
+      _androidPercyAppiumDriver.Setup(x => x.ExecuteScript(It.IsAny<string>()))
+        .Callback<string>(s => captured = s)
+        .Returns(response);
+      var appAutomate = new AppAutomate(_androidPercyAppiumDriver.Object);
+      appAutomate.metadata = new AndroidMetadata(_androidPercyAppiumDriver.Object, "Samsung Galaxy s22", 100, 200, null, null);
+      var options = new ScreenshotOptions();
+      options.FullPage = true;
+      options.ScreenLengths = 4;
+      // Act
+      var result = appAutomate.ExecutePercyScreenshot(options);
+      // Assert — the executor is actually reached, and asked for a fullpage capture
+      Assert.NotNull(result);
+      Assert.Contains("abcd-1234", result);
+      Assert.Contains("fullpage", captured);
+      Assert.DoesNotContain("singlepage", captured);
+    }
+
+    [Fact]
     public void TestExecutePercyScreenshotBegin_WhenSessionNotMarked()
     {
       // Arrange — first begin returns success=false, flipping markedPercySession to false

--- a/Percy/AppPercy.cs
+++ b/Percy/AppPercy.cs
@@ -64,7 +64,12 @@ namespace PercyIO.Appium
         {
           Utils.Log("The method is not valid for current driver. Please contact us.", "warn");
         }
-        Utils.Log("Error taking screenshot " + name);
+        // Name the exception on the default log line. Screenshot() swallows and returns null
+        // here, and percy-api redacts the message it receives via PostFailedEvent, so if this
+        // line drops the detail the only surviving copy is the executor's statusMessage in the
+        // App Automate hub log — which is where PER-10219 finally had to be read from.
+        Utils.Log($"Error taking screenshot {name} - {e.GetType().Name}: {e.Message}");
+        Utils.Log(e.ToString(), "debug");
         if (!ignoreErrors)
         {
           throw new Exception("Error taking screenshot " + name, e);

--- a/Percy/providers/AppAutomate.cs
+++ b/Percy/providers/AppAutomate.cs
@@ -226,25 +226,59 @@ namespace PercyIO.Appium
 
     internal Boolean VerifyCorrectAppiumVersion()
     {
-      var bstackOptions = percyAppiumDriver.GetCapabilities().getValue<Dictionary<string, object>>("bstack:options");
-      var appiumVersionJsonProtocol = percyAppiumDriver.GetCapabilities().getValue<String>("browserstack.appium_version");
-      if (bstackOptions == null && appiumVersionJsonProtocol == null)
+      try
       {
-        Utils.Log("Unable to fetch Appium version, Appium version should be >= 1.19 for Fullpage Screenshot", "warn");
+        var bstackOptions = percyAppiumDriver.GetCapabilities().getValue<Dictionary<string, object>>("bstack:options");
+        var appiumVersionJsonProtocol = percyAppiumDriver.GetCapabilities().getValue<String>("browserstack.appium_version");
+        if (bstackOptions == null && appiumVersionJsonProtocol == null)
+        {
+          Utils.Log("Unable to fetch Appium version, Appium version should be >= 1.19 for Fullpage Screenshot", "warn");
+        }
+        // `bstack:options` is present on every W3C session — the BrowserStack SDK always injects
+        // it — but `appiumVersion` is only inside it when the user pins one, so the key has to be
+        // probed rather than indexed. Indexing a missing key threw KeyNotFoundException out of
+        // this fullpage-only branch and surfaced to users as Screenshot() returning null with no
+        // snapshot ever posted. See PER-10219.
+        else if ((appiumVersionJsonProtocol != null && !AppiumVersionCheck(appiumVersionJsonProtocol))
+          || (bstackOptions != null
+              && bstackOptions.ContainsKey("appiumVersion")
+              && bstackOptions["appiumVersion"] != null
+              && !AppiumVersionCheck(bstackOptions["appiumVersion"].ToString())))
+        {
+          Utils.Log("Appium version should be >= 1.19 for Fullpage Screenshot, Falling back to single page screenshot.", "warn");
+          return false;
+        }
+        return true;
       }
-      else if ((appiumVersionJsonProtocol != null && !AppiumVersionCheck(appiumVersionJsonProtocol)) || (bstackOptions != null && !AppiumVersionCheck(bstackOptions["appiumVersion"].ToString())))
+      catch (Exception e)
       {
-        Utils.Log("Appium version should be >= 1.19 for Fullpage Screenshot, Falling back to single page screenshot.", "warn");
+        // Version detection must never take the screenshot down with it — an unverifiable
+        // version means the same thing as an unsupported one: fall back to single page.
+        Utils.Log("Unable to verify Appium version, Falling back to single page screenshot.", "warn");
+        Utils.Log(e.ToString(), "debug");
         return false;
       }
-      return true;
     }
 
     internal Boolean AppiumVersionCheck(String version)
     {
+      if (String.IsNullOrWhiteSpace(version))
+      {
+        return false;
+      }
+
+      // A pinned version can legitimately be major-only ("2"), so treat a missing minor as 0
+      // instead of indexing past the end of the array.
       string[] versionArr = version.Split('.');
-      int majorVersion = int.Parse(versionArr[0]);
-      int minorVersion = int.Parse(versionArr[1]);
+      if (!int.TryParse(versionArr[0], out int majorVersion))
+      {
+        return false;
+      }
+      int minorVersion = 0;
+      if (versionArr.Length > 1)
+      {
+        int.TryParse(versionArr[1], out minorVersion);
+      }
 
       if (majorVersion == 2 || (majorVersion == 1 && minorVersion > 18))
       {

--- a/Percy/providers/AppAutomate.cs
+++ b/Percy/providers/AppAutomate.cs
@@ -280,7 +280,11 @@ namespace PercyIO.Appium
         int.TryParse(versionArr[1], out minorVersion);
       }
 
-      if (majorVersion == 2 || (majorVersion == 1 && minorVersion > 18))
+      // The gate is "Appium >= 1.19". This was written as `== 2` when 2.x was the newest major,
+      // so Appium 3.x — which BrowserStack now offers and defaults to on newer devices — failed a
+      // check it comfortably satisfies, silently downgrading every fullpage request to single
+      // page. Compare as >= 2 so future majors don't regress the same way.
+      if (majorVersion >= 2 || (majorVersion == 1 && minorVersion > 18))
       {
         return true;
       }

--- a/Percy/providers/AppAutomate.cs
+++ b/Percy/providers/AppAutomate.cs
@@ -58,9 +58,10 @@ namespace PercyIO.Appium
           return result;
         }
       }
-      catch (Exception)
+      catch (Exception e)
       {
         Utils.Log("BrowserStack executer failed");
+        Utils.Log(e.ToString(), "debug");
       }
       return null;
     }
@@ -155,8 +156,9 @@ namespace PercyIO.Appium
       }
       catch (Exception e)
       {
-        var error = e.Message;
-        throw new Exception("Error", e);
+        // "Error" told a reader nothing about which stage failed; say what could not be parsed.
+        throw new Exception(
+          $"Could not parse tile data returned by the percyScreenshot executor: {e.Message}", e);
       }
       List<Tile> tiles = new List<Tile>();
       foreach (JObject jsonobject in jsonarray)


### PR DESCRIPTION
## Root cause of PER-10219 — confirmed

`AppPercy.Screenshot(..., FullPage=true)` throws `KeyNotFoundException` and silently returns null, so no snapshot is ever posted and the build finalizes with `Snapshot command was not called`.

Confirmed from the reporting customer's own App Automate session (`b2921c73…`), hub raw logs:

```
07:01:57.244  browserstack_executor percyScreenshot  state: "begin"   name: "Home Screen"
07:01:58.036  browserstack_executor percyScreenshot  state: "end"     status: "failure"
              statusMessage: "The given key 'appiumVersion' was not present in the dictionary."
```

`begin` fired, the `screenshot` state never did, and `end` reported failure 792 ms later. Execution died between them — in `VerifyCorrectAppiumVersion()`.

## Defect 1 — `KeyNotFoundException` when `appiumVersion` is absent

```csharp
|| (bstackOptions != null && !AppiumVersionCheck(bstackOptions["appiumVersion"].ToString()))
```

The map is null-checked but the key is not. `Dictionary`'s indexer throws `KeyNotFoundException` when `bstack:options` is readable but carries no `appiumVersion`.

This is reachable only on the fullpage path. In `ExecutePercyScreenshot`:

```csharp
if (!options.FullPage || (options.ScreenLengths != null && options.ScreenLengths < 2) || !VerifyCorrectAppiumVersion())
    screenshotType = "singlepage";
```

`||` short-circuits, so `FullPage=false` never evaluates the version check — which is exactly why regular screenshots kept uploading while fullpage produced nothing.

The throw then escapes unhandled: the `ExecutePercyScreenshot` call in `CaptureTiles` sits *outside* that method's try block, so it propagates through `GenericProvider.Screenshot` -> `AppAutomate.Screenshot` (rethrows, and its `finally` sends the `end` executor above) -> `AppPercy.Screenshot`, which swallows it and returns null because `ignoreErrors` defaults to true. `CliWrapper.PostScreenshot` is never reached.

Fixed by probing the key with `ContainsKey` + a null check, matching the guard `percy-appium-java` already carries (#357).

Note the failure is invisible from both ends: the catch logs only `Error taking screenshot <name>` and never `e.ToString()`, and percy-api's `SendEventsController` replaces the forwarded message with `REDACTED`. The only surviving copy of the exception text is the `statusMessage` in the hub executor log above.

## Defect 2 — Appium 3.x fails a ">= 1.19" check

Found while investigating the above. `AppiumVersionCheck` was written as `majorVersion == 2` when 2.x was the newest major; BrowserStack now offers 3.x:

```
AppiumVersionCheck("3.1.0")  => False      (2.0.0 => True)
```

When the version *is* readable and is 3.x, the check reports it as below 1.19 and downgrades the capture to single page — no error, just a warn line asserting the opposite of the truth. Not what bit this customer (they never got that far), but a live silent-downgrade bug. Fixed by comparing `>= 2`.

Also hardened: the check now falls back to single page rather than propagating if version detection fails at all, and a major-only pin (`appiumVersion: 2`) is treated as valid instead of running off the end of the split array.

Behaviour for a present, valid, 1.19–2.x `appiumVersion` is unchanged.

## Defect 3 — the exception was destroyed at every layer

This is why the root cause above took four rounds to find. When a screenshot fails:

- `AppPercy.Screenshot`'s catch logged only `Error taking screenshot <name>` and never `e.ToString()`, not even at debug.
- `percy-api`'s `SendEventsController` overwrites the message from `PostFailedEvent` with `REDACTED` before storing it.
- `CaptureTiles` rethrew parse failures as `Exception("Error")`, which identifies nothing.
- `ExecutePercyScreenshotBegin` swallowed its exception entirely, logging only `BrowserStack executer failed` (the `End` variant already logged detail).

The only surviving copy of the real message was the `statusMessage` that `AppAutomate.Screenshot`'s `finally` block sends to the `end` executor — readable solely in the App Automate hub raw log, which is where it was eventually found.

Now: the exception type and message appear on the default log line, the full stack is at debug, the tile-parse failure names its stage, and `Begin` logs its exception at debug like `End` does. `TestScreenshot_LogsTheExceptionDetail_WhenSwallowed` locks this in.

## When the capabilities expose a version

Worth recording, because it determines reachability. On a standalone `Appium.WebDriver` 5.x session I dumped all 30 capability keys the SDK reads: no `bstack:options`, no `browserstack.appiumVersion`, no `browserstack.appium_version`. There `VerifyCorrectAppiumVersion()` takes its first branch and returns `true`, and neither defect fires.

Under the BrowserStack SDK the shape differs — `bstack:options` *is* readable but without `appiumVersion` inside it, which is precisely the condition Defect 1 needs, and precisely what the customer session above shows.

## Cross-SDK note

`percy-appium-java` carries the Defect 1 guard but shares Defect 2 (`majorVersion == 2` at `AppAutomate.java:217`) — it needs the same Appium 3.x change.

## Tests

Nine tests added to `AppAutomateTest`, each verified to fail on `main` and pass with the fix:

```
TestVerifyCorrectAppiumVersion_WhenW3CWithoutAppiumVersionKey      KeyNotFoundException: The given key 'appiumVersion' was not present in the dictionary.
TestExecutePercyScreenshot_FullPageWhenW3CWithoutAppiumVersionKey  KeyNotFoundException
TestVerifyCorrectAppiumVersion_WhenW3CAppiumVersionIsNull          KeyNotFoundException
TestVerifyCorrectAppiumVersion_WhenAppiumThree                     returned false (silent singlepage)
TestAppiumVersionCheck_AcrossMajors                                3.1.0 / 4.0.0 rejected
TestVerifyCorrectAppiumVersion_WhenMajorOnlyVersion                IndexOutOfRangeException
TestVerifyCorrectAppiumVersion_WhenVersionIsUnparseable            FormatException
TestVerifyCorrectAppiumVersion_WhenCapabilityLookupThrows          (new fallback path)
TestAppiumVersionCheck_WhenVersionIsEmpty                          (new guard)
```

The first test's failure message is byte-identical to the `statusMessage` in the customer's session log.

The end-to-end case drives the real `PercyAppiumCapabilities` lookup rather than a stubbed `getValue`, so the missing-key path is genuinely exercised, and asserts the executor is reached with `screenshotType: fullpage`.

Existing coverage never caught either defect: every `TestVerifyCorrectAppiumVersion_*` case supplied an `appiumVersion`, and all used 1.x or 2.x.

CI green — 169/169, line coverage 99.43% against the 99% gate.

## Follow-up

- `percy-appium-java` needs the Appium 3.x fix.
- `browserstack-csharp-sdk` pins `PercyIO.Appium` 3.0.2 and needs a bump once this is released.
- Consider logging `e.ToString()` in `AppPercy.Screenshot`'s catch — the exception text is currently discarded client-side and redacted server-side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
