### PR TITLE
Release 3.0.10-beta.0

### DIFF
--- a/Percy/Percy.csproj
+++ b/Percy/Percy.csproj
@@ -9,7 +9,7 @@
     <PackageId>PercyIO.Appium</PackageId>
     <Description>An App Percy SDK for Appium WebDriver API .NET Bindings</Description>
     <PackageTags>appium;percy;visual;testing</PackageTags>
-    <Version>3.0.9</Version>
+    <Version>3.0.10-beta.0</Version>
     <Company>Perceptual Inc</Company>
     <Copyright>Copyright Perceptual Inc</Copyright>
     <Authors>percy-admin</Authors>


### PR DESCRIPTION
Bumps `PercyIO.Appium` to `3.0.10-beta.0`.

Pre-release ahead of `3.0.10`, so the fullpage fix can be validated downstream before a stable
version goes out.

## Included since 3.0.9

- **#416** — repair the fullpage Appium-version check and stop swallowing its errors
  - Fixes a `KeyNotFoundException` thrown when `bstack:options` is present but carries no
    `appiumVersion`. It escaped from the fullpage-only branch, so `Screenshot()` returned `null`
    and no snapshot was posted at all — silently, on every fullpage call.
  - Corrects the version gate itself: it was written as `major == 2`, so Appium 3.x failed a check
    it comfortably satisfies and every fullpage request was downgraded to single page.
  - Both protocols (`bstack:options.appiumVersion` and `browserstack.appium_version`) are now
    consulted, and numeric capabilities are judged rather than ignored, so an unquoted
    `appiumVersion` in `browserstack.yml` still enforces the gate.
  - Distinguishes "below the gate" from "could not determine": only the former downgrades, and
    each warning now states its consequence.
  - Surfaces the hub's own refusal message instead of a bare `NullReferenceException` when the
    executor returns no result.
  - Redacts credentials from log output, so an inline `user:accesskey@` in a hub URL no longer
    reaches an always-on log line.
- **#403** — CI only: allow running tests against an unpublished `@percy/cli` branch.

## Verification

- 196 tests passing, line coverage above the 99% gate.
- Live App Automate sessions confirm `fullpage` is requested and the snapshot uploads, and that
  `FullPage=false` still yields `singlepage` — checked in the hub logs rather than SDK output.

## Release steps

Publishing is triggered by a GitHub Release being published, not by this merge. After merging,
tag `v3.0.10-beta.0` and publish the release as a pre-release.